### PR TITLE
Undo patch+

### DIFF
--- a/patch/patch_undo.cpp
+++ b/patch/patch_undo.cpp
@@ -224,6 +224,20 @@ namespace patch {
         return *ObjectArrayPointer_ptr;
     }
 
+
+
+    void __stdcall undo_t::f4355c(ExEdit::Object* obj) {
+        AddUndoCount();
+        set_undo((reinterpret_cast<uintptr_t>(obj) - reinterpret_cast<uintptr_t>(*ObjectArrayPointer_ptr)) / sizeof(struct ExEdit::Object), 0);
+        *(int*)&obj->flag ^= 0x200;
+    }
+
+    void __stdcall undo_t::f435bd(ExEdit::Object* obj) {
+        AddUndoCount();
+        set_undo((reinterpret_cast<uintptr_t>(obj) - reinterpret_cast<uintptr_t>(*ObjectArrayPointer_ptr)) / sizeof(struct ExEdit::Object), 0);
+        *(int*)&obj->flag ^= 0x100;
+    }
+
 #ifdef PATCH_SWITCH_UNDO_REDO
 
     void __cdecl undo_t::init_undo_patch() {

--- a/patch/patch_undo.cpp
+++ b/patch/patch_undo.cpp
@@ -99,8 +99,8 @@ namespace patch {
         set_undo(object_idx, flag);
     }
 
-    int __cdecl undo_t::efRadiationalBlur_func_WndProc_wrap_06e2b4(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam, AviUtl::EditHandle* editp, ExEdit::Filter* efp) {
-        auto ret = efRadiationalBlur_func_WndProc(hwnd, message, wparam, lparam, editp, efp);
+    int __cdecl undo_t::efDraw_func_WndProc_wrap_06e2b4(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam, AviUtl::EditHandle* editp, ExEdit::Filter* efp) {
+        auto ret = efDraw_func_WndProc(hwnd, message, wparam, lparam, editp, efp);
         if (ret) return ret;
         if (LOWORD(wparam) == 7708) {
             AddUndoCount();

--- a/patch/patch_undo.hpp
+++ b/patch/patch_undo.hpp
@@ -639,17 +639,17 @@ namespace patch {
             }
 
             // テンキー2468+-*/ Ctrl+テンキー2468 で(座標XY 回転 拡大率 中心XY)トラックバーを変えてもUndoデータが生成されない
-            ReplaceNearJmp(GLOBAL::exedit_base + 0x01b710, &add_track_value_wrap); // Ctrl+テンキー2中心Y+, Ctrl+テンキー4中心X-
-            ReplaceNearJmp(GLOBAL::exedit_base + 0x01b73e, &add_track_value_wrap); // テンキー2座標Y+
             ReplaceNearJmp(GLOBAL::exedit_base + 0x01b611, &add_track_value_wrap); // テンキー4座標X-
             ReplaceNearJmp(GLOBAL::exedit_base + 0x01b646, &add_track_value_wrap); // Ctrl+テンキー6中心X+
             ReplaceNearJmp(GLOBAL::exedit_base + 0x01b674, &add_track_value_wrap); // テンキー6座標X+
             ReplaceNearJmp(GLOBAL::exedit_base + 0x01b6ab, &add_track_value_wrap); // Ctrl+テンキー8中心Y-
             ReplaceNearJmp(GLOBAL::exedit_base + 0x01b6db, &add_track_value_wrap); // テンキー8座標Y-
-            ReplaceNearJmp(GLOBAL::exedit_base + 0x01b7d4, &add_track_value_wrap); // テンキー*回転+
-            ReplaceNearJmp(GLOBAL::exedit_base + 0x01b78c, &add_track_value_wrap); // テンキー+拡大率+
+            ReplaceNearJmp(GLOBAL::exedit_base + 0x01b710, &add_track_value_wrap); // Ctrl+テンキー2中心Y+, Ctrl+テンキー4中心X-
+            ReplaceNearJmp(GLOBAL::exedit_base + 0x01b73e, &add_track_value_wrap); // テンキー2座標Y+
             ReplaceNearJmp(GLOBAL::exedit_base + 0x01b765, &add_track_value_wrap); // テンキー-拡大率-
+            ReplaceNearJmp(GLOBAL::exedit_base + 0x01b78c, &add_track_value_wrap); // テンキー+拡大率+
             ReplaceNearJmp(GLOBAL::exedit_base + 0x01b7b0, &add_track_value_wrap); // テンキー/回転-
+            ReplaceNearJmp(GLOBAL::exedit_base + 0x01b7d4, &add_track_value_wrap); // テンキー*回転+
 
             #ifdef PATCH_SWITCH_UNDO_REDO
                 if (!enable_redo())return;

--- a/patch/patch_undo.hpp
+++ b/patch/patch_undo.hpp
@@ -40,7 +40,7 @@ namespace patch {
 
 		inline static void(__cdecl*set_undo)(unsigned int, unsigned int);
         inline static void(__cdecl*AddUndoCount)();
-        inline static int(__cdecl*efRadiationalBlur_func_WndProc)(HWND, UINT, WPARAM, LPARAM, AviUtl::EditHandle*, ExEdit::Filter*);
+        inline static int(__cdecl*efDraw_func_WndProc)(HWND, UINT, WPARAM, LPARAM, AviUtl::EditHandle*, ExEdit::Filter*);
         inline static int(__cdecl*NormalizeExeditTimelineY)(int);
         
         inline constexpr static int UNDO_INTERVAL = 1000;
@@ -66,7 +66,7 @@ namespace patch {
 
         static void __cdecl set_undo_wrap_3e037(unsigned int object_idx, unsigned int flag);
 
-        static int __cdecl efRadiationalBlur_func_WndProc_wrap_06e2b4(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam, AviUtl::EditHandle* editp, ExEdit::Filter* efp);
+        static int __cdecl efDraw_func_WndProc_wrap_06e2b4(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam, AviUtl::EditHandle* editp, ExEdit::Filter* efp);
 
         static int __stdcall f8b97f(HWND hwnd, ExEdit::Filter* efp, WPARAM wparam, LPARAM lparam);
 
@@ -485,7 +485,7 @@ namespace patch {
 			
             set_undo = reinterpret_cast<decltype(set_undo)>(GLOBAL::exedit_base + 0x08d290);
             AddUndoCount = reinterpret_cast<decltype(AddUndoCount)>(GLOBAL::exedit_base + 0x08d150);
-            efRadiationalBlur_func_WndProc = reinterpret_cast<decltype(efRadiationalBlur_func_WndProc)>(GLOBAL::exedit_base + 0x01b550);
+            efDraw_func_WndProc = reinterpret_cast<decltype(efDraw_func_WndProc)>(GLOBAL::exedit_base + 0x01b550);
             NormalizeExeditTimelineY = reinterpret_cast<decltype(NormalizeExeditTimelineY)>(GLOBAL::exedit_base + 0x032c10);
 
 			// レイヤー削除→元に戻すで他シーンのオブジェクトが消える
@@ -506,7 +506,7 @@ namespace patch {
 			OverWriteOnProtectHelper(GLOBAL::exedit_base + 0x08d50e, 4).store_i32(0, '\x0f\x1f\x40\x00'); // nop
 
             // 部分フィルタのマスクの種類を変更してもUndoデータが生成されない
-            ReplaceNearJmp(GLOBAL::exedit_base + 0x06e2b5, &efRadiationalBlur_func_WndProc_wrap_06e2b4);
+            ReplaceNearJmp(GLOBAL::exedit_base + 0x06e2b5, &efDraw_func_WndProc_wrap_06e2b4);
 
             // テキストオブジェクトのフォントを変更してもUndoデータが生成されない
             {

--- a/patch/patch_undo.hpp
+++ b/patch/patch_undo.hpp
@@ -616,6 +616,18 @@ namespace patch {
                 h.replaceNearJmp(1, &f42617);
             }
 
+            // カメラ制御の対象 を切り替えてもUndoデータが生成されない
+            {
+                OverWriteOnProtectHelper h(GLOBAL::exedit_base + 0x04355b, 6);
+                h.store_i16(0, '\x51\xe8'); // push ecx, call (rel32)
+                h.replaceNearJmp(2, &f4355c);
+            }
+            // 上のオブジェクトでクリッピング を切り替えてもUndoデータが生成されない
+            {
+                OverWriteOnProtectHelper h(GLOBAL::exedit_base + 0x0435ba, 8);
+                h.store_i32(0, '\x90\x90\x50\xe8'); // nop, push eax, call (rel32)
+                h.replaceNearJmp(4, &f435bd);
+            }
 
             #ifdef PATCH_SWITCH_UNDO_REDO
                 if (!enable_redo())return;


### PR DESCRIPTION
undoデータが作られるべき操作で作られないバグの修正
・カメラ制御の対象 を切り替える (拡張編集の右クリックメニュー・設定ダイアログのカメラアイコン)
・上のオブジェクトでクリッピング を切り替える (拡張編集の右クリックメニュー・設定ダイアログの四角点々アイコン)
・テンキー周辺を押して設定ダイアログ表示中のオブジェクトを動かす