### PR TITLE
CI用 GitHub Actions workflowの追加

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: windows-2022
+    strategy:
+      matrix:
+        configuration: [Debug, Release]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Use Developer Command Prompt
+      uses: ilammy/msvc-dev-cmd@v1
+    - name: Install CUDA Toolkit
+      uses: Jimver/cuda-toolkit@v0.2.7
+    - name: Setup NuGet
+      uses: nuget/setup-nuget@v1
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v1.1
+      with:
+        msbuild-architecture: x64
+    - name: Restore NuGet package
+      run : nuget restore patch.sln
+    - name: Create Directories
+      run : |
+        mkdir pack
+        mkdir test
+    - name: Build patch.aul
+      run : msbuild /nologo /t:Build /p:Configuration=${{ matrix.configuration }} /p:Platform="x86" patch.sln 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,10 +22,6 @@ jobs:
       uses: Jimver/cuda-toolkit@v0.2.7
     - name: Setup NuGet
       uses: nuget/setup-nuget@v1
-    - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.1
-      with:
-        msbuild-architecture: x64
     - name: Restore NuGet package
       run : nuget restore patch.sln
     - name: Create Directories
@@ -33,4 +29,4 @@ jobs:
         mkdir pack
         mkdir test
     - name: Build patch.aul
-      run : msbuild /nologo /t:Build /p:Configuration=${{ matrix.configuration }} /p:Platform="x86" patch.sln 
+      run : devenv patch.sln /Build "${{ matrix.configuration }}|x86"

--- a/patch/patch.vcxproj
+++ b/patch/patch.vcxproj
@@ -198,7 +198,7 @@
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <AdditionalIncludeDirectories>aviutl_exedit_sdk;winwrap;%CUDA_PATH%\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalOptions>/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/source-charset:utf-8 /execution-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
@@ -230,7 +230,7 @@ xcopy /Y "$(SolutionDir)COPYING.LESSER" "$(SolutionDir)pack\"</Command>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <AdditionalIncludeDirectories>aviutl_exedit_sdk;winwrap;%CUDA_PATH%\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalOptions>/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/source-charset:utf-8 /execution-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>


### PR DESCRIPTION
AviUtlを用いたテストは行いません。
patch.aulのビルドテストのみを行います。

他者からのプルリク受け取り時に、ビルド可能かの判断材料にできると思われます。
また、過去のとあるコミットがビルド可能かの判断が容易になります。