### PR TITLE
拡張編集のバグ修正5つ

### DIFF
--- a/patch.aul.txt
+++ b/patch.aul.txt
@@ -66,6 +66,11 @@ https://scrapbox.io/ePi5131/patch.aul
     ・拡張編集以外のフィルタのトラックバーにトラックバー変化方法スクリプトを適用していると例外になる問題
     ・小さい画像に対してサイズ固定で範囲の大きいレンズブラーを掛けると例外になるのを修正
     ・拡張色変換のウィンドウが下のフィルタに被るのを修正
+    ・右クリック分割で設定ダイアログが更新されないのを修正
+    ・右クリック削除でテキストの字間行間が変わることがあるのを修正
+    ・標準描画-拡張描画-パーティクルの切り替え時にトラック変化の設定値(移動フレーム間隔)が0になるのを修正
+    ・トラック変化方式の移動量指定と時間制御の組み合わせでバグるのを修正
+    ・アルファチャンネル有りシーンで合成モード「通常」以外を使用すると、他シーンで表示した時の結果が正しくないのを修正
 
     追加
     ・コンソールの表示
@@ -160,6 +165,8 @@ https://scrapbox.io/ePi5131/patch.aul
         "exo_track_minusval" : boolean, ; オブジェクトファイルの入力で、トラックバーの -1 超 0 未満の値が正になってしまう (既定値: true)
         "exo_specialcolorconv" : boolean, ; オブジェクトファイルの入出力で、特定色域変換のstatusが2つあって正しく入出力できない (既定値: true)
         "tra_aviutlfilter" : boolean, ; 拡張色変換のウィンドウが下のフィルタに被るのを修正 (既定値: true)
+		"tra_change_drawfilter" : boolean, ; 標準描画-拡張描画-パーティクルの切り替え時にトラック変化の設定値(移動フレーム間隔)が0になるのを修正 (既定値: true)
+		"tra_specified_speed" : boolean, ; トラック変化方式の移動量指定と時間制御の組み合わせでバグるのを修正 (既定値: true)
 		"text_op_size" : boolean, ; テキストオブジェクトでUTF-16で34バイト以上のフォント名を指定している時、制御文字<s>でサイズのみを指定していると正しい動作をしない (既定値: true)
         "ignore_media_param_reset" : boolean, ; 動画ファイル と 音声ファイル で中間点を打っていないときでもファイルを再参照しても再生位置などの情報を変更しない (既定値: false)
 		"theme_cc" : boolean, ; テーマ機能 (既定値: true)
@@ -167,6 +174,9 @@ https://scrapbox.io/ePi5131/patch.aul
         "settingdialog_move" : boolean, ; 設定ダイアログを高ポーリングレートマウス環境で移動すると重たい の解消 (既定値: true)
 		"obj_lensblur" : boolean, ; 小さい画像に対してサイズ固定で範囲の大きいレンズブラーを掛けると例外になるのを修正 (既定値: true)
 		"settingdialog_excolorconfig" : boolean, ; 
+		"r_click_menu_split" : boolean, ; 右クリック分割で設定ダイアログが更新されないのを修正 (既定値: true)
+		"r_click_menu_delete" : boolean, ; 右クリック削除でテキストの字間行間が変わることがあるのを修正 (既定値: true)
+		"blend" : boolean, ; アルファチャンネル有りシーンで合成モード「通常」以外を使用すると、他シーンで表示した時の結果が正しくないのを修正 (既定値: true)
         "undo" : boolean, ; 元に戻す 関連のバグ修正 (既定値: true)
         "undo.redo" : boolean, ; やり直す を追加 (既定値: true)
 		"console" : boolean, ; コンソール (既定値: true)

--- a/patch/config.hpp
+++ b/patch/config.hpp
@@ -83,6 +83,12 @@ public:
             #ifdef PATCH_SWITCH_TRA_AVIUTL_FILTER
                 patch::tra_aviutlfilter.switch_load(cr);
             #endif
+            #ifdef PATCH_SWITCH_TRA_CHANGE_DRAWFILTER
+                patch::tra_change_drawfilter.switch_load(cr);
+            #endif
+            #ifdef PATCH_SWITCH_TRA_SPECIFIED_SPEED
+                patch::tra_specified_speed.switch_load(cr);
+            #endif
 		    #ifdef PATCH_SWITCH_TEXT_OP_SIZE
                 patch::text_op_size.switch_load(cr);
 		    #endif
@@ -116,6 +122,12 @@ public:
             #ifdef PATCH_SWITCH_SETTINGDIALOG_EXCOLORCONFIG
                 patch::excolorconfig.switch_load(cr);
 		    #endif
+            #ifdef PATCH_SWITCH_RCLICKMENU_SPLIT
+                patch::rclickmenu_split.switch_load(cr);
+            #endif
+            #ifdef PATCH_SWITCH_RCLICKMENU_DELETE
+                patch::rclickmenu_delete.switch_load(cr);
+            #endif
 		
 		    #ifdef PATCH_SWITCH_UNDO
                 patch::undo.switch_load(cr);
@@ -337,6 +349,12 @@ public:
             #ifdef PATCH_SWITCH_TRA_AVIUTL_FILTER
                 patch::tra_aviutlfilter.switch_store(switch_);
             #endif
+            #ifdef PATCH_SWITCH_TRA_CHANGE_DRAWFILTER
+                patch::tra_change_drawfilter.switch_store(switch_);
+            #endif
+            #ifdef PATCH_SWITCH_TRA_SPECIFIED_SPEED
+                patch::tra_specified_speed.switch_store(switch_);
+            #endif
 		    #ifdef PATCH_SWITCH_TEXT_OP_SIZE
                 patch::text_op_size.switch_store(switch_);
 		    #endif
@@ -370,6 +388,12 @@ public:
 		    #ifdef PATCH_SWITCH_SETTINGDIALOG_EXCOLORCONFIG
                 patch::excolorconfig.switch_store(switch_);
 		    #endif
+            #ifdef PATCH_SWITCH_RCLICKMENU_SPLIT
+                patch::rclickmenu_split.switch_store(switch_);
+            #endif
+            #ifdef PATCH_SWITCH_RCLICKMENU_DELETE
+                patch::rclickmenu_delete.switch_store(switch_);
+            #endif
 
 		    #ifdef PATCH_SWITCH_UNDO
                 patch::undo.switch_store(switch_);

--- a/patch/config.hpp
+++ b/patch/config.hpp
@@ -128,6 +128,9 @@ public:
             #ifdef PATCH_SWITCH_RCLICKMENU_DELETE
                 patch::rclickmenu_delete.switch_load(cr);
             #endif
+            #ifdef PATCH_SWITCH_BLEND
+                patch::blend.switch_load(cr);
+            #endif
 		
 		    #ifdef PATCH_SWITCH_UNDO
                 patch::undo.switch_load(cr);
@@ -393,6 +396,9 @@ public:
             #endif
             #ifdef PATCH_SWITCH_RCLICKMENU_DELETE
                 patch::rclickmenu_delete.switch_store(switch_);
+            #endif
+            #ifdef PATCH_SWITCH_BLEND
+                patch::blend.switch_store(switch_);
             #endif
 
 		    #ifdef PATCH_SWITCH_UNDO

--- a/patch/init.cpp
+++ b/patch/init.cpp
@@ -100,6 +100,13 @@ void init_t::InitAtExeditLoad() {
 #ifdef PATCH_SWITCH_TRA_AVIUTL_FILTER
 	patch::tra_aviutlfilter.init();
 #endif
+#ifdef PATCH_SWITCH_TRA_CHANGE_DRAWFILTER
+	patch::tra_change_drawfilter.init();
+#endif
+#ifdef PATCH_SWITCH_TRA_SPECIFIED_SPEED
+	patch::tra_specified_speed.init();
+#endif
+
 
 #ifdef PATCH_SWITCH_EXO_AVIUTL_FILTER
 	patch::exo_aviutlfilter.init();
@@ -151,6 +158,13 @@ void init_t::InitAtExeditLoad() {
 
 #ifdef PATCH_SWITCH_SETTINGDIALOG_EXCOLORCONFIG
 	patch::excolorconfig.init();
+#endif
+
+#ifdef PATCH_SWITCH_RCLICKMENU_SPLIT
+	patch::rclickmenu_split.init();
+#endif
+#ifdef PATCH_SWITCH_RCLICKMENU_DELETE
+	patch::rclickmenu_delete.init();
 #endif
 	
 	patch::setting_dialog();

--- a/patch/init.cpp
+++ b/patch/init.cpp
@@ -166,6 +166,9 @@ void init_t::InitAtExeditLoad() {
 #ifdef PATCH_SWITCH_RCLICKMENU_DELETE
 	patch::rclickmenu_delete.init();
 #endif
+#ifdef PATCH_SWITCH_BLEND
+	patch::blend.init();
+#endif
 	
 	patch::setting_dialog();
 

--- a/patch/macro.h
+++ b/patch/macro.h
@@ -101,6 +101,8 @@
 
 #define PATCH_SWITCH_ACCESS_KEY access_key
 #define PATCH_SWITCH_TRA_AVIUTL_FILTER tra_aviutl_filter
+#define PATCH_SWITCH_TRA_CHANGE_DRAWFILTER tra_change_drawfilter
+#define PATCH_SWITCH_TRA_SPECIFIED_SPEED tra_specified_speed
 #define PATCH_SWITCH_EXO_AVIUTL_FILTER exo_aviutl_filter
 #define PATCH_SWITCH_EXO_TRACK_MINUSVAL exo_track_minusval
 #define PATCH_SWITCH_EXO_SCENEIDX exo_sceneidx
@@ -115,6 +117,8 @@
 #define PATCH_SWITCH_CANCEL_BOOST_CONFLICT
 #define PATCH_SWITCH_WARNING_OLD_LSW
 #define PATCH_SWITCH_OBJ_LENSBLUR obj_lensblur
+#define PATCH_SWITCH_RCLICKMENU_SPLIT rclickmenu_split
+#define PATCH_SWITCH_RCLICKMENU_DELETE rclickmenu_delete
 
 #define PATCH_SWITCH_UNDO undo
 #ifdef PATCH_SWITCH_UNDO

--- a/patch/macro.h
+++ b/patch/macro.h
@@ -119,6 +119,7 @@
 #define PATCH_SWITCH_OBJ_LENSBLUR obj_lensblur
 #define PATCH_SWITCH_RCLICKMENU_SPLIT rclickmenu_split
 #define PATCH_SWITCH_RCLICKMENU_DELETE rclickmenu_delete
+#define PATCH_SWITCH_BLEND blend
 
 #define PATCH_SWITCH_UNDO undo
 #ifdef PATCH_SWITCH_UNDO

--- a/patch/offset_address.hpp
+++ b/patch/offset_address.hpp
@@ -28,6 +28,9 @@ namespace OFS {
 	}
 
 	namespace ExEdit {
+		constexpr i32 blend_yca_normal_func = 0x007df0;
+		constexpr i32 blend_yc_normal_func = 0x007f20;
+		
 		constexpr i32 ConvertFilter2Exo_TrackScaleJudge_RangeBegin = 0x028a8d;
 		constexpr i32 ConvertFilter2Exo_TrackScaleJudge_Overwrite1 = 0x028a84;
 		constexpr i32 ConvertFilter2Exo_TrackScaleJudge_Overwrite2 = 0x0289cb;

--- a/patch/offset_address.hpp
+++ b/patch/offset_address.hpp
@@ -83,6 +83,11 @@ namespace OFS {
 		constexpr i32 exfunc_1c = 0x04ade0;
 		constexpr i32 GetCurrentProcessing = 0x047ba0;
 		constexpr i32 LoadedFilterTable = 0x187c98;
+		constexpr i32 splitted_object_new_group_belong = 0x034f90;
+		constexpr i32 DrawTimelineMask = 0x0392f0;
+		constexpr i32 disp_settingdialog = 0x039550;
+		constexpr i32 filter_sendmessage = 0x04a1a0;
+		constexpr i32 get_near_object_idx = 0x0445a0;
 		constexpr i32 TraScript_ProcessingObjectIndex = 0x1b2b04;
 		constexpr i32 TraScript_ProcessingTrackBarIndex = 0x1b21f4;
 		constexpr i32 TraScript_Time = 0x1b28c8;

--- a/patch/patch.hpp
+++ b/patch/patch.hpp
@@ -58,3 +58,7 @@
 #include "patch_setting_dialog_excolorconfig.hpp"
 #include "patch_fast_border.hpp"
 #include "patch_fast_directionalblur.hpp"
+#include "patch_rclickmenu_split.hpp"
+#include "patch_rclickmenu_delete.hpp"
+#include "patch_tra_change_drawfilter.hpp"
+#include "patch_tra_specified_speed.hpp"

--- a/patch/patch.hpp
+++ b/patch/patch.hpp
@@ -62,3 +62,4 @@
 #include "patch_rclickmenu_delete.hpp"
 #include "patch_tra_change_drawfilter.hpp"
 #include "patch_tra_specified_speed.hpp"
+#include "patch_blend.hpp"

--- a/patch/patch_blend.cpp
+++ b/patch/patch_blend.cpp
@@ -1,0 +1,275 @@
+/*
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "patch_blend.hpp"
+
+#ifdef PATCH_SWITCH_BLEND
+namespace patch {
+
+    void __cdecl blend_t::blend_yca_add(ExEdit::PixelYCA* dst, int src_y, int src_cb, int src_cr, int src_a) {
+        src_y += dst->y * dst->a >> 12;
+        src_cb += dst->cb * dst->a >> 12;
+        src_cr += dst->cr * dst->a >> 12;
+        if (0x2000 < src_y) {
+            if (src_y < 0x3000) {
+                src_cb = (0x3000 - src_y) * src_cb >> 12;
+                src_cr = (0x3000 - src_y) * src_cr >> 12;
+            } else {
+                src_cb = src_cr = 0;
+            }
+            src_y = 0x2000;
+        }
+        blend_yca_normal(dst, src_y, src_cb, src_cr, src_a);
+    }
+
+
+    void __cdecl blend_t::blend_yca_sub(ExEdit::PixelYCA* dst, int src_y, int src_cb, int src_cr, int src_a) {
+        src_y = (dst->y * dst->a >> 12) - src_y;
+        src_cb = (dst->cb * dst->a >> 12) - src_cb;
+        src_cr = (dst->cr * dst->a >> 12) - src_cr;
+        if (src_y < 0) {
+            if (src_y <= -0x400) {
+                src_cb = src_cr = 0;
+            } else {
+                src_cb = (src_y + 0x400) * src_cb >> 10;
+                src_cr = (src_y + 0x400) * src_cr >> 10;
+            }
+            src_y = 0;
+        }
+        blend_yca_normal(dst, src_y, src_cb, src_cr, src_a);
+    }
+
+    void __cdecl blend_t::blend_yca_mul(ExEdit::PixelYCA* dst, int src_y, int src_cb, int src_cr, int src_a) {
+        int fix_y = dst->y * dst->a >> 12;
+        int fix_cb = dst->cb * dst->a >> 12;
+        int fix_cr = dst->cr * dst->a >> 12;
+        int src_t = max(0, (src_cr * 0x59ba >> 14) + src_y);
+        int dst_t = max(0, (fix_cr * 0x59ba >> 14) + fix_y);
+        int r = min(src_t * dst_t >> 12, 0x2000);
+
+        src_t = max(0, (src_cb * -0x1604 + src_cr * -0x2db2 >> 14) + src_y);
+        dst_t = max(0, (fix_cb * -0x1604 + fix_cr * -0x2db2 >> 14) + fix_y);
+        int g = min(src_t * dst_t >> 12, 0x2000);
+
+        src_t = max(0, (src_cb * 0x7168 >> 14) + src_y);
+        dst_t = max(0, (fix_cb * 0x7168 >> 14) + fix_y);
+        int b = min(src_t * dst_t >> 12, 0x2000);
+
+        src_y = r * 0x1322 + g * 0x2591 + b * 0x74b >> 14;
+        src_cb = r * -0xad0 + g * -0x152f + b * 0x2000 >> 14;
+        src_cr = r * 0x2000 + g * -0x1ad0 + b * -0x52f >> 14;
+
+        blend_yca_normal(dst, src_y, src_cb, src_cr, src_a);
+    }
+
+    void __cdecl blend_t::blend_yca_screen(ExEdit::PixelYCA* dst, int src_y, int src_cb, int src_cr, int src_a) {
+        int fix_y = dst->y * dst->a >> 12;
+        int fix_cb = dst->cb * dst->a >> 12;
+        int fix_cr = dst->cr * dst->a >> 12;
+        int src_t = max(0, (src_cr * 0x59ba >> 14) + src_y);
+        int dst_t = max(0, (fix_cr * 0x59ba >> 14) + fix_y);
+        int r = dst_t - (dst_t * src_t >> 12) + src_t;
+
+        src_t = max(0, (src_cb * -0x1604 + src_cr * -0x2db2 >> 14) + src_y);
+        dst_t = max(0, (fix_cb * -0x1604 + fix_cr * -0x2db2 >> 14) + fix_y);
+        int g = dst_t - (dst_t * src_t >> 12) + src_t;
+
+        src_t = max(0, (src_cb * 0x7168 >> 14) + src_y);
+        dst_t = max(0, (fix_cb * 0x7168 >> 14) + fix_y);
+        int b = dst_t - (dst_t * src_t >> 12) + src_t;
+
+        src_y = r * 0x1322 + g * 0x2591 + b * 0x74b >> 14;
+        src_cb = r * -0xad0 + g * -0x152f + b * 0x2000 >> 14;
+        src_cr = r * 0x2000 + g * -0x1ad0 + b * -0x52f >> 14;
+
+        blend_yca_normal(dst, src_y, src_cb, src_cr, src_a);
+    }
+
+    void __cdecl blend_t::blend_yca_overlay(ExEdit::PixelYCA* dst, int src_y, int src_cb, int src_cr, int src_a) {
+        int fix_y = dst->y * dst->a >> 12;
+        int fix_cb = dst->cb * dst->a >> 12;
+        int fix_cr = dst->cr * dst->a >> 12;
+        int src_t = max(0, (src_cr * 0x59ba >> 14) + src_y);
+        int dst_t = max(0, (fix_cr * 0x59ba >> 14) + fix_y);
+        int r = dst_t * src_t >> 11;
+        if (0x800 <= dst_t) {
+            r = (dst_t + src_t) * 2 - 0x1000 - r;
+        }
+
+        src_t = max(0, (src_cb * -0x1604 + src_cr * -0x2db2 >> 14) + src_y);
+        dst_t = max(0, (fix_cb * -0x1604 + fix_cr * -0x2db2 >> 14) + fix_y);
+        int g = dst_t * src_t >> 11;
+        if (0x800 <= dst_t) {
+            g = (dst_t + src_t) * 2 - 0x1000 - g;
+        }
+
+        src_t = max(0, (src_cb * 0x7168 >> 14) + src_y);
+        dst_t = max(0, (fix_cb * 0x7168 >> 14) + fix_y);
+        int b = dst_t * src_t >> 11;
+        if (0x800 <= dst_t) {
+            b = (dst_t + src_t) * 2 - 0x1000 - b;
+        }
+
+        src_y = r * 0x1322 + g * 0x2591 + b * 0x74b >> 14;
+        src_cb = r * -0xad0 + g * -0x152f + b * 0x2000 >> 14;
+        src_cr = r * 0x2000 + g * -0x1ad0 + b * -0x52f >> 14;
+
+        blend_yca_normal(dst, src_y, src_cb, src_cr, src_a);
+    }
+
+    void __cdecl blend_t::blend_yca_cmpmax(ExEdit::PixelYCA* dst, int src_y, int src_cb, int src_cr, int src_a) {
+        int fix_y = dst->y * dst->a >> 12;
+        int fix_cb = dst->cb * dst->a >> 12;
+        int fix_cr = dst->cr * dst->a >> 12;
+        int r = max((src_cr * 0x59ba >> 14) + src_y, (fix_cr * 0x59ba >> 14) + fix_y);
+        int g = max((src_cb * -0x1604 + src_cr * -0x2db2 >> 14) + src_y, (fix_cb * -0x1604 + fix_cr * -0x2db2 >> 14) + fix_y);
+        int b = max((src_cb * 0x7168 >> 14) + src_y, (fix_cb * 0x7168 >> 14) + fix_y);
+
+        src_y = r * 0x1322 + g * 0x2591 + b * 0x74b >> 14;
+        src_cb = r * -0xad0 + g * -0x152f + b * 0x2000 >> 14;
+        src_cr = r * 0x2000 + g * -0x1ad0 + b * -0x52f >> 14;
+
+        blend_yca_normal(dst, src_y, src_cb, src_cr, src_a);
+    }
+
+    void __cdecl blend_t::blend_yca_cmpmin(ExEdit::PixelYCA* dst, int src_y, int src_cb, int src_cr, int src_a) {
+        int fix_y = dst->y * dst->a >> 12;
+        int fix_cb = dst->cb * dst->a >> 12;
+        int fix_cr = dst->cr * dst->a >> 12;
+        int r = min((src_cr * 0x59ba >> 14) + src_y, (fix_cr * 0x59ba >> 14) + fix_y);
+        int g = min((src_cb * -0x1604 + src_cr * -0x2db2 >> 14) + src_y, (fix_cb * -0x1604 + fix_cr * -0x2db2 >> 14) + fix_y);
+        int b = min((src_cb * 0x7168 >> 14) + src_y, (fix_cb * 0x7168 >> 14) + fix_y);
+
+        src_y = r * 0x1322 + g * 0x2591 + b * 0x74b >> 14;
+        src_cb = r * -0xad0 + g * -0x152f + b * 0x2000 >> 14;
+        src_cr = r * 0x2000 + g * -0x1ad0 + b * -0x52f >> 14;
+
+        blend_yca_normal(dst, src_y, src_cb, src_cr, src_a);
+    }
+
+
+    void __cdecl blend_t::blend_yca_luminance(ExEdit::PixelYCA* dst, short src_y, short src_cb, short src_cr, short src_a) {
+        if (0x1000 <= src_a) {
+            dst->y = src_y;
+            dst->cb = dst->cb * dst->a >> 12;
+            dst->cr = dst->cr * dst->a >> 12;
+            dst->a = 0x1000;
+        } else if (0x1000 <= dst->a) {
+            dst->y += (src_y - dst->y) * src_a >> 12;
+            dst->a = 0x1000;
+        } else if (dst->a <= 0) {
+            dst->y = src_y;
+            dst->cb = 0;
+            dst->cr = 0;
+            dst->a = src_a;
+        } else {
+            short new_a = 0x1000800 - (0x1000 - dst->a) * (0x1000 - src_a) >> 12;
+            dst->y = ((dst->y * dst->a >> 12) * (0x1000 - src_a) + src_y * src_a) / new_a;
+            dst->cb = dst->cb * dst->a / new_a;
+            dst->cr = dst->cr * dst->a / new_a;
+            dst->a = new_a;
+        }
+    }
+
+    void __cdecl blend_t::blend_yca_colordiff(ExEdit::PixelYCA* dst, short src_y, short src_cb, short src_cr, short src_a) {
+        if (0x1000 <= src_a) {
+            dst->y = dst->y * dst->a >> 12;
+            dst->cb = src_cb;
+            dst->cr = src_cr;
+            dst->a = 0x1000;
+        } else if (0x1000 <= dst->a) {
+            dst->cb += (src_cb - dst->cb) * src_a >> 12;
+            dst->cr += (src_cr - dst->cr) * src_a >> 12;
+            dst->a = 0x1000;
+        } else if (dst->a <= 0) {
+            dst->y = 0;
+            dst->cb = src_cb;
+            dst->cr = src_cr;
+            dst->a = src_a;
+        } else {
+            int new_a = 0x1000800 - (0x1000 - dst->a) * (0x1000 - src_a) >> 12;
+            int new_dst_a = (0x1000 - src_a) * dst->a / new_a;
+            int new_src_a = (src_a << 12) / new_a;
+            dst->y = dst->y * dst->a / new_a;
+            dst->cb = dst->cb * new_dst_a + src_cb * new_src_a >> 12;
+            dst->cr = dst->cr * new_dst_a + src_cr * new_src_a >> 12;
+            dst->a = new_a;
+        }
+    }
+
+    void __cdecl blend_t::blend_yca_shadow(ExEdit::PixelYCA* dst, int src_y, int src_cb, int src_cr, int src_a) {
+        int fix_y = dst->y * dst->a >> 12;
+        int fix_cb = dst->cb * dst->a >> 12;
+        int fix_cr = dst->cr * dst->a >> 12;
+        int src_t = max(0, (src_cr * 0x59ba >> 14) + src_y);
+        int dst_t = max(0, (fix_cr * 0x59ba >> 14) + fix_y);
+        int r = max(0, dst_t + src_t - 0x1000);
+
+        src_t = max(0, (src_cb * -0x1604 + src_cr * -0x2db2 >> 14) + src_y);
+        dst_t = max(0, (fix_cb * -0x1604 + fix_cr * -0x2db2 >> 14) + fix_y);
+        int g = max(0, dst_t + src_t - 0x1000);
+
+        src_t = max(0, (src_cb * 0x7168 >> 14) + src_y);
+        dst_t = max(0, (fix_cb * 0x7168 >> 14) + fix_y);
+        int b = max(0, dst_t + src_t - 0x1000);
+
+        src_y = r * 0x1322 + g * 0x2591 + b * 0x74b >> 14;
+        src_cb = r * -0xad0 + g * -0x152f + b * 0x2000 >> 14;
+        src_cr = r * 0x2000 + g * -0x1ad0 + b * -0x52f >> 14;
+
+        blend_yca_normal(dst, src_y, src_cb, src_cr, src_a);
+    }
+
+    void __cdecl blend_t::blend_yca_lightdark(ExEdit::PixelYCA* dst, int src_y, int src_cb, int src_cr, int src_a) {
+        int fix_y = dst->y * dst->a >> 12;
+        int fix_cb = dst->cb * dst->a >> 12;
+        int fix_cr = dst->cr * dst->a >> 12;
+        int src_t = (src_cr * 0x59ba >> 14) + src_y;
+        int dst_t = (fix_cr * 0x59ba >> 14) + fix_y;
+        int r = std::clamp(dst_t + src_t * 2 - 0x1000, 0, 0x2000);
+
+        src_t = (src_cb * -0x1604 + src_cr * -0x2db2 >> 14) + src_y;
+        dst_t = (fix_cb * -0x1604 + fix_cr * -0x2db2 >> 14) + fix_y;
+        int g = std::clamp(dst_t + src_t * 2 - 0x1000, 0, 0x2000);
+
+        src_t = (src_cb * 0x7168 >> 14) + src_y;
+        dst_t = (fix_cb * 0x7168 >> 14) + fix_y;
+        int b = std::clamp(dst_t + src_t * 2 - 0x1000, 0, 0x2000);
+
+        src_y = r * 0x1322 + g * 0x2591 + b * 0x74b >> 14;
+        src_cb = r * -0xad0 + g * -0x152f + b * 0x2000 >> 14;
+        src_cr = r * 0x2000 + g * -0x1ad0 + b * -0x52f >> 14;
+
+        blend_yca_normal(dst, src_y, src_cb, src_cr, src_a);
+    }
+
+    void __cdecl blend_t::blend_yca_difference(ExEdit::PixelYCA* dst, int src_y, int src_cb, int src_cr, int src_a) {
+        int sub_y = src_y - (dst->y * dst->a >> 12);
+        int sub_cb = src_cb - (dst->cb * dst->a >> 12);
+        int sub_cr = src_cr - (dst->cr * dst->a >> 12);
+
+        int r = abs((sub_cr * 0x59ba >> 14) + sub_y);
+        int g = abs((sub_cb * -0x1604 + sub_cr * -0x2db2 >> 14) + sub_y);
+        int b = abs((sub_cb * 0x7168 >> 14) + sub_y);
+
+        src_y = r * 0x1322 + g * 0x2591 + b * 0x74b >> 14;
+        src_cb = r * -0xad0 + g * -0x152f + b * 0x2000 >> 14;
+        src_cr = r * 0x2000 + g * -0x1ad0 + b * -0x52f >> 14;
+
+        blend_yca_normal(dst, src_y, src_cb, src_cr, src_a);
+    }
+
+} // namespace patch
+#endif // ifdef PATCH_SWITCH_BLEND

--- a/patch/patch_blend.hpp
+++ b/patch/patch_blend.hpp
@@ -1,0 +1,217 @@
+/*
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+#include "macro.h"
+
+#ifdef PATCH_SWITCH_BLEND
+
+#include <memory>
+#include <exedit.hpp>
+
+#include "global.hpp"
+#include "offset_address.hpp"
+#include "util.hpp"
+#include "restorable_patch.hpp"
+
+#include "config_rw.hpp"
+
+namespace patch {
+	// init at exedit load
+	// 合成モード関数の修正(主にアルファチャンネル有りシーンオブジェクト)
+	inline class blend_t {
+		static void __cdecl blend_yca_add(ExEdit::PixelYCA* dst, int src_y, int src_cb, int src_cr, int src_a);
+		static void __cdecl blend_yca_sub(ExEdit::PixelYCA* dst, int src_y, int src_cb, int src_cr, int src_a);
+		static void __cdecl blend_yca_mul(ExEdit::PixelYCA* dst, int src_y, int src_cb, int src_cr, int src_a);
+		static void __cdecl blend_yca_screen(ExEdit::PixelYCA* dst, int src_y, int src_cb, int src_cr, int src_a);
+		static void __cdecl blend_yca_overlay(ExEdit::PixelYCA* dst, int src_y, int src_cb, int src_cr, int src_a);
+		static void __cdecl blend_yca_cmpmax(ExEdit::PixelYCA* dst, int src_y, int src_cb, int src_cr, int src_a);
+		static void __cdecl blend_yca_cmpmin(ExEdit::PixelYCA* dst, int src_y, int src_cb, int src_cr, int src_a);
+		static void __cdecl blend_yca_luminance(ExEdit::PixelYCA* dst, short src_y, short src_cb, short src_cr, short src_a);
+		static void __cdecl blend_yca_colordiff(ExEdit::PixelYCA* dst, short src_y, short src_cb, short src_cr, short src_a);
+		static void __cdecl blend_yca_shadow(ExEdit::PixelYCA* dst, int src_y, int src_cb, int src_cr, int src_a);
+		static void __cdecl blend_yca_lightdark(ExEdit::PixelYCA* dst, int src_y, int src_cb, int src_cr, int src_a);
+		static void __cdecl blend_yca_difference(ExEdit::PixelYCA* dst, int src_y, int src_cb, int src_cr, int src_a);
+
+		bool enabled = true;
+		bool enabled_i;
+
+		inline static const char key[] = "blend";
+
+
+	public:
+
+		inline static void(__cdecl* blend_yca_normal)(void* dst, int src_y, int src_cb, int src_cr, int src_a);
+
+		void init() {
+			enabled_i = enabled;
+
+			if (!enabled_i)return;
+
+			blend_yca_normal = reinterpret_cast<decltype(blend_yca_normal)>(GLOBAL::exedit_base + OFS::ExEdit::blend_yca_normal_func);
+			{
+				OverWriteOnProtectHelper h(GLOBAL::exedit_base + 0x9fbb4, 48);
+				h.store_i32(0, &blend_yca_add);
+				h.store_i32(4, &blend_yca_sub);
+				h.store_i32(8, &blend_yca_mul);
+				h.store_i32(12, &blend_yca_screen);
+				h.store_i32(16, &blend_yca_overlay);
+				h.store_i32(20, &blend_yca_cmpmax);
+				h.store_i32(24, &blend_yca_cmpmin);
+				h.store_i32(28, &blend_yca_luminance);
+				h.store_i32(32, &blend_yca_colordiff);
+				h.store_i32(36, &blend_yca_shadow);
+				h.store_i32(40, &blend_yca_lightdark);
+				h.store_i32(44, &blend_yca_difference);
+			}
+
+            char blend_yca_normal_bin[] = {
+                "\x8b\x4c\x24\x04"         // mov     ecx,dword ptr [esp+04]
+                "\x8b\x54\x24\x14"         // mov     edx,dword ptr [esp+14]
+                "\xb8\x00\x10\x00\x00"     // mov     eax,00001000
+                "\x3b\xd0"                 // cmp     edx,eax
+                "\x7c\x1f"                 // jl      10007e20
+                "\x66\x89\x41\x06"         // mov     [ecx+06],ax
+                "\x66\x8b\x44\x24\x08"     // mov     ax,[esp+08]
+                "\x66\x8b\x54\x24\x0c"     // mov     dx,[esp+0c]
+                "\x66\x89\x01"             // mov     [ecx],ax
+                "\x66\x8b\x44\x24\x10"     // mov     ax,[esp+10]
+                "\x66\x89\x51\x02"         // mov     [ecx+02],dx
+                "\x66\x89\x41\x04"         // mov     [ecx+04],ax
+                "\xc3"                     // ret
+                "\x56"                     // push    esi
+                "\x0f\xbf\x71\x06"         // movsx   esi,dword ptr [ecx+06]
+                "\x3b\xf0"                 // cmp     esi,eax
+                "\x7c\x40"                 // jl      10007e69
+                "\x66\x89\x41\x06"         // mov     [ecx+06],ax
+                "\x0f\xbf\x31"             // movsx   esi,dword ptr [ecx]
+                "\x8b\x44\x24\x0c"         // mov     eax,dword ptr [esp+0c]
+                "\x2b\xc6"                 // sub     eax,esi
+                "\x0f\xaf\xc2"             // imul    eax,edx
+                "\xc1\xf8\x0c"             // sar     eax,0c
+                "\x66\x01\x01"             // add     [ecx],ax
+                "\x0f\xbf\x71\x02"         // movsx   esi,dword ptr [ecx+02]
+                "\x8b\x44\x24\x10"         // mov     eax,dword ptr [esp+10]
+                "\x2b\xc6"                 // sub     eax,esi
+                "\x0f\xaf\xc2"             // imul    eax,edx
+                "\xc1\xf8\x0c"             // sar     eax,0c
+                "\x66\x01\x41\x02"         // add     [ecx+02],ax
+                "\x0f\xbf\x71\x04"         // movsx   esi,dword ptr [ecx+04]
+                "\x8b\x44\x24\x14"         // mov     eax,dword ptr [esp+14]
+                "\x2b\xc6"                 // sub     eax,esi
+                "\x0f\xaf\xc2"             // imul    eax,edx
+                "\xc1\xf8\x0c"             // sar     eax,0c
+                "\x66\x01\x41\x04"         // add     [ecx+04],ax
+                "\x5e"                     // pop     esi
+                "\xc3"                     // ret
+                "\x85\xf6"                 // test    esi,esi
+                "\x7f\x20"                 // jg      10007e90
+                "\x66\x89\x51\x06"         // mov     [ecx+06],dx
+                "\x66\x8b\x44\x24\x0c"     // mov     ax,[esp+0c]
+                "\x66\x8b\x54\x24\x10"     // mov     dx,[esp+10]
+                "\x66\x89\x01"             // mov     [ecx],ax
+                "\x66\x8b\x44\x24\x14"     // mov     ax,[esp+14]
+                "\x66\x89\x51\x02"         // mov     [ecx+02],dx
+                "\x66\x89\x41\x04"         // mov     [ecx+04],ax
+                "\x5e"                     // pop     esi
+                "\xc3"                     // ret
+                "\x53"                     // push    ebx
+                "\x8b\xd8"                 // mov     ebx,eax
+                "\x2b\xde"                 // sub     ebx,esi
+                "\x2b\xc2"                 // sub     eax,edx
+                "\x0f\xaf\xd8"             // imul    ebx,eax
+                "\x0f\xaf\xc6"             // imul    eax,esi
+                "\xbe\x00\x08\x00\x01"     // mov     esi,01000800
+                "\x2b\xf3"                 // sub     esi,ebx
+                "\xc1\xfe\x0c"             // sar     esi,0c
+                "\x66\x89\x71\x06"         // mov     [ecx+06],si
+                "\x99"                     // cdq
+                "\xf7\xfe"                 // idiv    esi
+                "\x8b\xd8"                 // mov     ebx,eax
+                "\x8b\x44\x24\x1c"         // mov     eax,dword ptr [esp+1c]
+                "\xc1\xe0\x0c"             // shl     eax,0c
+                "\x99"                     // cdq
+                "\xf7\xfe"                 // idiv    esi
+                "\x0f\xbf\x11"             // movsx   edx,dword ptr [ecx]
+                "\x0f\xaf\xd3"             // imul    edx,ebx
+                "\x8b\x74\x24\x10"         // mov     esi,dword ptr [esp+10]
+                "\x0f\xaf\xf0"             // imul    esi,eax
+                "\x03\xd6"                 // add     edx,esi
+                "\xc1\xfa\x0c"             // sar     edx,0c
+                "\x66\x89\x11"             // mov     [ecx],dx
+                "\x0f\xbf\x51\x02"         // movsx   edx,dword ptr [ecx+02]
+                "\x0f\xaf\xd3"             // imul    edx,ebx
+                "\x8b\x74\x24\x14"         // mov     esi,dword ptr [esp+14]
+                "\x0f\xaf\xf0"             // imul    esi,eax
+                "\x03\xd6"                 // add     edx,esi
+                "\xc1\xfa\x0c"             // sar     edx,0c
+                "\x66\x89\x51\x02"         // mov     [ecx+02],dx
+                "\x0f\xbf\x51\x04"         // movsx   edx,dword ptr [ecx+04]
+                "\x0f\xaf\xd3"             // imul    edx,ebx
+                "\x8b\x74\x24\x18"         // mov     esi,dword ptr [esp+18]
+                "\x0f\xaf\xf0"             // imul    esi,eax
+                "\x03\xd6"                 // add     edx,esi
+                "\xc1\xfa\x0c"             // sar     edx,0c
+                "\x66\x89\x51\x04"         // mov     [ecx+04],dx
+                "\x5b"                     // pop     ebx
+                "\x5e"                     // pop     esi
+                "\xc3"                     // ret
+            };
+            {
+                OverWriteOnProtectHelper h(GLOBAL::exedit_base + OFS::ExEdit::blend_yca_normal_func, sizeof(blend_yca_normal_bin) - 1);
+                memcpy(reinterpret_cast<void*>(h.address()), blend_yca_normal_bin, sizeof(blend_yca_normal_bin) - 1);
+            }
+            {
+                char blend_yc_normal_bin[] = {
+                    "\x8b\x4c\x24\x04"         // mov     ecx,dword ptr [esp+04]
+                    "\x8b\x54\x24\x14"         // mov     edx,dword ptr [esp+14]
+                    "\x81\xfa\x00\x10\x00\x00" // cmp     edx,00001000
+                    "\x7c\x1b"                 // jl      10007f4b
+                    "\x66\x8b\x44\x24\x08"     // mov     ax,[esp+08]
+                    "\x66\x8b\x54\x24\x0c"     // mov     dx,[esp+0c]
+                    "\x66\x89\x01"             // mov     [ecx],ax
+                    "\x66\x8b\x44\x24\x10"     // mov     ax,[esp+10]
+                    "\x66\x89\x51\x02"         // mov     [ecx+02],dx
+                    "\x66\x89\x41\x04"         // mov     [ecx+04],ax
+                    "\xc3"                     // ret
+                    "\x56"                     // push    esi
+                };
+                OverWriteOnProtectHelper h(GLOBAL::exedit_base + OFS::ExEdit::blend_yc_normal_func, 104);
+                memcpy(reinterpret_cast<void*>(h.address()), blend_yc_normal_bin, sizeof(blend_yc_normal_bin) - 1);
+                memcpy(reinterpret_cast<void*>(h.address() + sizeof(blend_yc_normal_bin) - 1), &blend_yca_normal_bin[61], 60);
+            }
+
+
+		}
+		void switching(bool flag) {
+			enabled = flag;
+		}
+
+		bool is_enabled() { return enabled; }
+		bool is_enabled_i() { return enabled_i; }
+
+		void switch_load(ConfigReader& cr) {
+			cr.regist(key, [this](json_value_s* value) {
+				ConfigReader::load_variable(value, enabled);
+				});
+		}
+
+		void switch_store(ConfigWriter& cw) {
+			cw.append(key, enabled);
+		}
+
+	} blend;
+} // namespace patch
+#endif // ifdef PATCH_SWITCH_BLEND

--- a/patch/patch_rclickmenu_delete.cpp
+++ b/patch/patch_rclickmenu_delete.cpp
@@ -30,8 +30,8 @@ namespace patch {
 	void __cdecl rclickmenu_delete_t::DrawTimelineMask_wrap3ff68(int* to_draw) {
 		if (0 <= last_id) {
 			reinterpret_cast<void(__cdecl*)(int)>(GLOBAL::exedit_base + OFS::ExEdit::disp_settingdialog)(last_id);
+			last_id = -1;
 		}
-		last_id = -1;
 		reinterpret_cast<void(__cdecl*)(int*)>(GLOBAL::exedit_base + OFS::ExEdit::DrawTimelineMask)(to_draw);
 	}
 

--- a/patch/patch_rclickmenu_delete.cpp
+++ b/patch/patch_rclickmenu_delete.cpp
@@ -1,0 +1,39 @@
+/*
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "patch_rclickmenu_delete.hpp"
+
+#ifdef PATCH_SWITCH_RCLICKMENU_DELETE
+namespace patch {
+
+	void __cdecl rclickmenu_delete_t::disp_near_settingdialog_wrap3fef6() {
+		if (0 <= *settingdialog_object_idx_ptr) {
+			int object_idx = *settingdialog_object_idx_ptr;
+			if (*selecting_obj_num_ptr) {
+				object_idx = selecting_obj_list[0];
+			}
+			last_id = reinterpret_cast<int(__cdecl*)(int, int)>(GLOBAL::exedit_base + OFS::ExEdit::get_near_object_idx)(object_idx, 1);
+		}
+	}
+	void __cdecl rclickmenu_delete_t::DrawTimelineMask_wrap3ff68(int* to_draw) {
+		if (0 <= last_id) {
+			reinterpret_cast<void(__cdecl*)(int)>(GLOBAL::exedit_base + OFS::ExEdit::disp_settingdialog)(last_id);
+		}
+		last_id = -1;
+		reinterpret_cast<void(__cdecl*)(int*)>(GLOBAL::exedit_base + OFS::ExEdit::DrawTimelineMask)(to_draw);
+	}
+
+} // namespace patch
+#endif // ifdef PATCH_SWITCH_RCLICKMENU_DELETE

--- a/patch/patch_rclickmenu_delete.hpp
+++ b/patch/patch_rclickmenu_delete.hpp
@@ -1,0 +1,85 @@
+/*
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+#include "macro.h"
+
+#ifdef PATCH_SWITCH_RCLICKMENU_DELETE
+
+#include <memory>
+#include <exedit.hpp>
+
+#include "global.hpp"
+#include "offset_address.hpp"
+#include "util.hpp"
+#include "restorable_patch.hpp"
+
+#include "config_rw.hpp"
+
+namespace patch {
+	// init at exedit load
+	// 右クリックメニューの削除でテキストの字間・行間が変わることがあるのを修正
+	// 設定ダイアログの更新タイミングを変えることで修正
+	inline class rclickmenu_delete_t {
+		static void __cdecl disp_near_settingdialog_wrap3fef6();
+		static void __cdecl DrawTimelineMask_wrap3ff68(int* to_draw);
+
+		bool enabled = true;
+		bool enabled_i;
+
+		inline static const char key[] = "r_click_menu_delete";
+
+		inline static int last_id = -1;
+
+	public:
+
+		inline static int* settingdialog_object_idx_ptr;
+		inline static int* selecting_obj_num_ptr;
+		inline static int* selecting_obj_list;
+
+
+		void init() {
+			enabled_i = enabled;
+
+			if (!enabled_i)return;
+
+			settingdialog_object_idx_ptr = reinterpret_cast<decltype(settingdialog_object_idx_ptr)>(GLOBAL::exedit_base + 0x177a10);
+			selecting_obj_num_ptr = reinterpret_cast<decltype(selecting_obj_num_ptr)>(GLOBAL::exedit_base + 0x167d88);
+			selecting_obj_list = reinterpret_cast<decltype(selecting_obj_list)>(GLOBAL::exedit_base + 0x179230);
+
+			ReplaceNearJmp(GLOBAL::exedit_base + 0x03fef6, &disp_near_settingdialog_wrap3fef6);
+			ReplaceNearJmp(GLOBAL::exedit_base + 0x03ff68, &DrawTimelineMask_wrap3ff68);
+
+		}
+		void switching(bool flag) {
+			enabled = flag;
+		}
+
+		bool is_enabled() { return enabled; }
+		bool is_enabled_i() { return enabled_i; }
+
+		void switch_load(ConfigReader& cr) {
+			cr.regist(key, [this](json_value_s* value) {
+				ConfigReader::load_variable(value, enabled);
+				});
+		}
+
+		void switch_store(ConfigWriter& cw) {
+			cw.append(key, enabled);
+		}
+
+	} rclickmenu_delete;
+} // namespace patch
+#endif // ifdef PATCH_SWITCH_RCLICKMENU_DELETE

--- a/patch/patch_rclickmenu_split.cpp
+++ b/patch/patch_rclickmenu_split.cpp
@@ -19,14 +19,14 @@
 namespace patch {
 
 	int __cdecl rclickmenu_split_t::filter_sendmessage_wrap3fd46(int object_idx, int wparam, int flag) {
-		if (last_id == -1) {
+		if (last_id < 0) {
 			last_id = object_idx;
 		}
 		return reinterpret_cast<int(__cdecl*)(int,int,int)>(GLOBAL::exedit_base + OFS::ExEdit::filter_sendmessage)(object_idx, wparam, flag);
 	}
 
 	void __cdecl rclickmenu_split_t::splitted_object_new_group_belong_wrap3fd5c() {
-		if (last_id != -1) {
+		if (0 <= last_id) {
 			reinterpret_cast<void(__cdecl*)(int)>(GLOBAL::exedit_base + OFS::ExEdit::disp_settingdialog)(last_id);
 			last_id = -1;
 		}

--- a/patch/patch_rclickmenu_split.cpp
+++ b/patch/patch_rclickmenu_split.cpp
@@ -1,0 +1,37 @@
+/*
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "patch_rclickmenu_split.hpp"
+
+#ifdef PATCH_SWITCH_RCLICKMENU_SPLIT
+namespace patch {
+
+	int __cdecl rclickmenu_split_t::filter_sendmessage_wrap3fd46(int object_idx, int wparam, int flag) {
+		if (last_id == -1) {
+			last_id = object_idx;
+		}
+		return reinterpret_cast<int(__cdecl*)(int,int,int)>(GLOBAL::exedit_base + OFS::ExEdit::filter_sendmessage)(object_idx, wparam, flag);
+	}
+
+	void __cdecl rclickmenu_split_t::splitted_object_new_group_belong_wrap3fd5c() {
+		if (last_id != -1) {
+			reinterpret_cast<void(__cdecl*)(int)>(GLOBAL::exedit_base + OFS::ExEdit::disp_settingdialog)(last_id);
+			last_id = -1;
+		}
+		reinterpret_cast<void(__cdecl*)(void)>(GLOBAL::exedit_base + OFS::ExEdit::splitted_object_new_group_belong)();
+
+	}
+} // namespace patch
+#endif // ifdef PATCH_SWITCH_RCLICKMENU_SPLIT

--- a/patch/patch_rclickmenu_split.hpp
+++ b/patch/patch_rclickmenu_split.hpp
@@ -1,0 +1,75 @@
+/*
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+#include "macro.h"
+
+#ifdef PATCH_SWITCH_RCLICKMENU_SPLIT
+
+#include <memory>
+#include <exedit.hpp>
+
+#include "global.hpp"
+#include "offset_address.hpp"
+#include "util.hpp"
+#include "restorable_patch.hpp"
+
+#include "config_rw.hpp"
+
+namespace patch {
+	// init at exedit load
+	// 右クリックメニューの分割で設定ダイアログの更新が行われないのを修正
+	inline class rclickmenu_split_t {
+		static int __cdecl filter_sendmessage_wrap3fd46(int object_idx, int wparam, int flag);
+		static void __cdecl splitted_object_new_group_belong_wrap3fd5c();
+
+		bool enabled = true;
+		bool enabled_i;
+
+		inline static const char key[] = "r_click_menu_split";
+
+		inline static int last_id = -1;
+
+	public:
+
+		void init() {
+			enabled_i = enabled;
+
+			if (!enabled_i)return;
+
+			ReplaceNearJmp(GLOBAL::exedit_base + 0x03fd46, &filter_sendmessage_wrap3fd46);
+			ReplaceNearJmp(GLOBAL::exedit_base + 0x03fd5c, &splitted_object_new_group_belong_wrap3fd5c);
+
+		}
+		void switching(bool flag) {
+			enabled = flag;
+		}
+
+		bool is_enabled() { return enabled; }
+		bool is_enabled_i() { return enabled_i; }
+
+		void switch_load(ConfigReader& cr) {
+			cr.regist(key, [this](json_value_s* value) {
+				ConfigReader::load_variable(value, enabled);
+				});
+		}
+
+		void switch_store(ConfigWriter& cw) {
+			cw.append(key, enabled);
+		}
+
+	} rclickmenu_split;
+} // namespace patch
+#endif // ifdef PATCH_SWITCH_RCLICKMENU_SPLIT

--- a/patch/patch_tra_change_drawfilter.cpp
+++ b/patch/patch_tra_change_drawfilter.cpp
@@ -1,0 +1,50 @@
+/*
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "patch_tra_change_drawfilter.hpp"
+
+#ifdef PATCH_SWITCH_TRA_CHANGE_DRAWFILTER
+namespace patch {
+
+	int __cdecl tra_change_drawfilter_t::switch_drawfilter_trackdata_to_mem(int* data, int object_idx, int track_begin, int track_id) {
+		if (0 <= track_id) {
+			auto& eop = (*ObjectArrayPointer_ptr)[object_idx];
+			int tr = track_begin + track_id;
+			data[0] = eop.track_value_left[tr];
+			data[1] = eop.track_value_right[tr];
+			data[2] = *(int*)&eop.track_mode[tr];
+			data[3] = eop.track_param[tr];
+			return 4;
+		}
+		return 0;
+	}
+
+	int __cdecl tra_change_drawfilter_t::switch_drawfilter_mem_to_trackdata(int* data, int object_idx, int track_begin, int pre_track_exists, int track_id) {
+		if (0 <= pre_track_exists) {
+			if (0 <= track_id) {
+				auto& eop = (*ObjectArrayPointer_ptr)[object_idx];
+				int tr = track_begin + track_id;
+				eop.track_value_left[tr] = data[0];
+				eop.track_value_right[tr] = data[1];
+				*(int*)&eop.track_mode[tr] = data[2];
+				eop.track_param[tr] = data[3];
+			}
+			return 4;
+		}
+		return 0;
+	}
+
+} // namespace patch
+#endif // ifdef PATCH_SWITCH_TRA_CHANGE_DRAWFILTER

--- a/patch/patch_tra_change_drawfilter.hpp
+++ b/patch/patch_tra_change_drawfilter.hpp
@@ -1,0 +1,87 @@
+/*
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+#include "macro.h"
+
+#ifdef PATCH_SWITCH_TRA_CHANGE_DRAWFILTER
+
+#include <memory>
+#include <exedit.hpp>
+
+#include "global.hpp"
+#include "offset_address.hpp"
+#include "util.hpp"
+#include "restorable_patch.hpp"
+
+#include "config_rw.hpp"
+
+namespace patch {
+	// init at exedit load
+	// 標準描画-拡張描画-パーティクル出力 を切り替えた際にトラックの設定値(移動フレーム間隔)が0になるのを修正
+	// 値を引き継ぐための関数に足りていなかったので追加した関数を置き換える
+	inline class tra_change_drawfilter_t {
+		static int __cdecl switch_drawfilter_trackdata_to_mem(int* data, int object_idx, int track_begin, int track_id);
+		static int __cdecl switch_drawfilter_mem_to_trackdata(int* data, int object_idx, int track_begin, int pre_track_exists, int track_id);
+
+		bool enabled = true;
+		bool enabled_i;
+
+		inline static const char key[] = "tra_change_drawfilter";
+
+		inline static ExEdit::Object** ObjectArrayPointer_ptr;
+
+	public:
+
+		void init() {
+			enabled_i = enabled;
+
+			if (!enabled_i)return;
+
+			ObjectArrayPointer_ptr = reinterpret_cast<decltype(ObjectArrayPointer_ptr)>(GLOBAL::exedit_base + OFS::ExEdit::ObjectArrayPointer);
+
+			{
+				OverWriteOnProtectHelper h(GLOBAL::exedit_base + 0x44280, 5);
+				h.store_i8(0, '\xe9'); // jmp
+				h.replaceNearJmp(1, &switch_drawfilter_trackdata_to_mem);
+			}
+			{
+				OverWriteOnProtectHelper h(GLOBAL::exedit_base + 0x44530, 5);
+				h.store_i8(0, '\xe9'); // jmp
+				h.replaceNearJmp(1, &switch_drawfilter_mem_to_trackdata);
+			}
+
+
+		}
+		void switching(bool flag) {
+			enabled = flag;
+		}
+
+		bool is_enabled() { return enabled; }
+		bool is_enabled_i() { return enabled_i; }
+
+		void switch_load(ConfigReader& cr) {
+			cr.regist(key, [this](json_value_s* value) {
+				ConfigReader::load_variable(value, enabled);
+				});
+		}
+
+		void switch_store(ConfigWriter& cw) {
+			cw.append(key, enabled);
+		}
+
+	} tra_change_drawfilter;
+} // namespace patch
+#endif // ifdef PATCH_SWITCH_TRA_CHANGE_DRAWFILTER

--- a/patch/patch_tra_specified_speed.hpp
+++ b/patch/patch_tra_specified_speed.hpp
@@ -1,0 +1,104 @@
+/*
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+#include "macro.h"
+
+#ifdef PATCH_SWITCH_TRA_SPECIFIED_SPEED
+
+#include <memory>
+#include <exedit.hpp>
+
+#include "global.hpp"
+#include "offset_address.hpp"
+#include "util.hpp"
+#include "restorable_patch.hpp"
+
+#include "config_rw.hpp"
+
+namespace patch {
+	// init at exedit load
+	// トラック変化方式の「移動量指定」で計算が足りていなかった（主に時間制御との組み合わせでバグる）のを修正
+	inline class tra_specified_speed_t {
+
+		bool enabled = true;
+		bool enabled_i;
+
+		inline static const char key[] = "tra_specified_speed";
+
+	public:
+
+        void init() {
+            enabled_i = enabled;
+
+            if (!enabled_i)return;
+
+            auto& cursor = GLOBAL::executable_memory_cursor;
+
+            /*
+				1006821c 8b8cb7f8000000     mov     ecx,dword ptr [edi+esi*4+000000f8] ;ecx = obj[object_idx].track_value_left[track_begin]
+				10068223 0faf442458         imul    eax,dword ptr [esp+58] ;eax *= obj_frame
+				↓
+				1006821c e8XxXxXxXx         call    bin_data
+				10068221 8b8cb7f8000000     mov     ecx,dword ptr [edi+esi*4+000000f8] ;ecx = obj[object_idx].track_value_left[track_begin]
+
+
+				; arg3_subframeが0以外の時はobj_frameが100倍されてarg3_subframeが加算されている
+				; 移動量指定では100で割るコードを忘れている
+            */
+
+
+			OverWriteOnProtectHelper h(GLOBAL::exedit_base + 0x06821c, 12);
+			h.store_i8(0, '\xe8');
+			h.replaceNearJmp(1, cursor);
+			h.store_i32(5, '\x8b\x8c\xb7\xf8');
+			h.store_i32(8, '\xf8\x00\x00\x00'); // \xf8は範囲ダブらせてstore_i32 * 2 で行っています
+
+			static const char code_put[] =
+				"\x0f\xaf\x44\x24\x5c"     // imul    eax,dword ptr [esp+5c] ;eax *= obj_frame
+				"\x8b\x4d\x10"             // mov     ecx,dword ptr [ebp+10] ;ecx = arg3_subframe
+				"\x85\xc9"                 // test    ecx,ecx
+				"\x74\x08"                 // jz      skip 8 byte ;if(ecx == 0)return
+				"\xb9\x64\x00\x00\x00"     // mov     ecx,00000064 ;ecx = 100
+				"\x99"                     // cdq
+				"\xf7\xf9"                 // idiv    ecx ;edx = eax % ecx, eax /= ecx
+				"\xc3"                     // ret      ;return
+				;
+
+            memcpy(cursor, code_put, sizeof(code_put) - 1);
+
+            cursor += sizeof(code_put) - 1;
+        }
+
+		void switching(bool flag) {
+			enabled = flag;
+		}
+
+		bool is_enabled() { return enabled; }
+		bool is_enabled_i() { return enabled_i; }
+
+		void switch_load(ConfigReader& cr) {
+			cr.regist(key, [this](json_value_s* value) {
+				ConfigReader::load_variable(value, enabled);
+				});
+		}
+
+		void switch_store(ConfigWriter& cw) {
+			cw.append(key, enabled);
+		}
+
+	} tra_specified_speed;
+} // namespace patch
+#endif // ifdef PATCH_SWITCH_TRA_SPECIFIED_SPEED


### PR DESCRIPTION
以下を修正
･右クリック分割で設定ダイアログが更新されない
･右クリック削除でテキストの字間行間が変わる
･標準描画-拡張描画-パーティクルの切り替え時にトラック変化の設定値(移動フレーム間隔)が0になる
･トラック変化の移動量指定が時間制御でバグる
･アルファチャンネル有りシーンで合成モード「通常」以外を使用すると他シーンで表示した時の結果が正しくない