### PR TITLE
特定色域変換で変換前色に黒色を指定すると0除算が起こることがあるのを修正

### DIFF
--- a/patch.aul.txt
+++ b/patch.aul.txt
@@ -77,6 +77,7 @@ https://scrapbox.io/ePi5131/patch.aul
     ・アルファチャンネル有りシーンで合成モード「通常」以外を使用すると、他シーンで表示した時の結果が正しくないのを修正
     ・ファイルパスが原因の「対応していないフォーマット～」エラーのメッセージを変更する
     ・色調補正の色相計算を修正
+    ・特定色域変換で変換前色に黒色を指定すると0除算が起こることがあるのを修正
 
     追加
     ・コンソールの表示
@@ -182,6 +183,7 @@ https://scrapbox.io/ePi5131/patch.aul
 		"obj_colorcorrection" : boolean, ; 色調補正の色相計算を修正 (既定値: true)
 		"obj_lensblur" : boolean, ; 小さい画像に対してサイズ固定で範囲の大きいレンズブラーを掛けると例外になるのを修正 (既定値: true)
 		"obj_noise" : boolean, ; ノイズの速度X、変化速度のトラック変化方法が移動無し以外の時に速度Yの値をもとに計算が行われてしまうのを修正 (既定値: true)
+		"obj_specialcolorconv" : boolean, ; 特定色域変換で変換前色に黒色を指定すると0除算が起こることがあるのを修正 (既定値: true)
 		"settingdialog_excolorconfig" : boolean, ; 拡張色変換のウィンドウが下のフィルタに被るのを修正 (既定値: true)
 		"r_click_menu_split" : boolean, ; 右クリック分割で設定ダイアログが更新されないのを修正 (既定値: true)
 		"r_click_menu_delete" : boolean, ; 右クリック削除でテキストの字間行間が変わることがあるのを修正 (既定値: true)

--- a/patch/config.hpp
+++ b/patch/config.hpp
@@ -128,6 +128,9 @@ public:
             #ifdef PATCH_SWITCH_OBJ_NOISE
                 patch::Noise.switch_load(cr);
             #endif
+            #ifdef PATCH_SWITCH_OBJ_SPECIALCOLORCONV
+                patch::obj_specialcolorconv.switch_load(cr);
+            #endif
             #ifdef PATCH_SWITCH_SETTINGDIALOG_EXCOLORCONFIG
                 patch::excolorconfig.switch_load(cr);
 		    #endif
@@ -411,6 +414,9 @@ public:
             #endif
             #ifdef PATCH_SWITCH_OBJ_NOISE
                 patch::Noise.switch_store(switch_);
+            #endif
+            #ifdef PATCH_SWITCH_OBJ_SPECIALCOLORCONV
+                patch::obj_specialcolorconv.switch_store(switch_);
             #endif
 		    #ifdef PATCH_SWITCH_SETTINGDIALOG_EXCOLORCONFIG
                 patch::excolorconfig.switch_store(switch_);

--- a/patch/init.cpp
+++ b/patch/init.cpp
@@ -165,6 +165,9 @@ void init_t::InitAtExeditLoad() {
 #ifdef PATCH_SWITCH_OBJ_NOISE
 	patch::Noise.init();
 #endif
+#ifdef PATCH_SWITCH_OBJ_SPECIALCOLORCONV
+	patch::obj_specialcolorconv.init();
+#endif
 
 #ifdef PATCH_SWITCH_SETTINGDIALOG_EXCOLORCONFIG
 	patch::excolorconfig.init();

--- a/patch/macro.h
+++ b/patch/macro.h
@@ -120,6 +120,7 @@
 #define PATCH_SWITCH_OBJ_COLORCORRECTION obj_colorcorrection
 #define PATCH_SWITCH_OBJ_LENSBLUR obj_lensblur
 #define PATCH_SWITCH_OBJ_NOISE obj_noise
+#define PATCH_SWITCH_OBJ_SPECIALCOLORCONV obj_specialcolorconv
 #define PATCH_SWITCH_RCLICKMENU_SPLIT rclickmenu_split
 #define PATCH_SWITCH_RCLICKMENU_DELETE rclickmenu_delete
 #define PATCH_SWITCH_BLEND blend

--- a/patch/patch.hpp
+++ b/patch/patch.hpp
@@ -68,3 +68,4 @@
 #include "patch_blend.hpp"
 #include "patch_failed_sjis_msgbox.hpp"
 #include "patch_obj_colorcorrection.hpp"
+#include "patch_obj_specialcolorconv.hpp"

--- a/patch/patch_obj_specialcolorconv.hpp
+++ b/patch/patch_obj_specialcolorconv.hpp
@@ -1,0 +1,149 @@
+/*
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+#include "macro.h"
+#ifdef PATCH_SWITCH_OBJ_SPECIALCOLORCONV
+
+#include <memory>
+
+#include "util.hpp"
+
+#include "config_rw.hpp"
+
+namespace patch {
+    // init at exedit load
+    // 特定色域変換で変換前色に黒色を指定すると0除算が起こることがあるのを修正
+
+    /*
+        問題のコード
+        if (pix_y < before_y) {
+            after_y = (after_y * pix_y) / before_y;
+        }
+
+        今回行った修正は以下を追加 (Yが負の値を取らない前提で作られていたようなので)
+        if (pix_y < 0) {
+            pix_y = 0;
+        }
+
+    */
+
+    inline class obj_specialcolorconv_t {
+
+        bool enabled = true;
+        bool enabled_i;
+
+        inline static const char key[] = "obj_specialcolorconv";
+
+
+    public:
+        void init() {
+            enabled_i = enabled;
+
+            if (!enabled_i)return;
+
+            auto& cursor = GLOBAL::executable_memory_cursor;
+            {
+                {
+                    OverWriteOnProtectHelper h(GLOBAL::exedit_base + 0x015cca, 7);
+                    h.store_i32(0, '\x90\x90\xe8\x00');
+                    h.replaceNearJmp(3, cursor);
+                }
+                {
+                    OverWriteOnProtectHelper h(GLOBAL::exedit_base + 0x015e25, 7);
+                    h.store_i32(0, '\x90\x90\xe8\x00');
+                    h.replaceNearJmp(3, cursor);
+                }
+                {
+                    OverWriteOnProtectHelper h(GLOBAL::exedit_base + 0x015f77, 7);
+                    h.store_i32(0, '\x90\x90\xe8\x00');
+                    h.replaceNearJmp(3, cursor);
+                }
+
+                {
+                    /*
+                        10015f77 0fbf31             movsx   esi,dword ptr [ecx]
+                        10015f7a 0fbf5d00           movsx   ebx,dword ptr [ebp+00]
+
+                        ↓
+
+                        10015f77 9090               nop
+                        10015f79 e8XxXxXxXx         call    executable_memory_cursor
+
+                            ; esi(pix->y)が0未満の場合、0にする
+                    */
+                    static const char code_put[] =
+                        "\x0f\xbf\x31"             // movsx   esi,dword ptr [ecx]
+                        "\x0f\xbf\x5d\x00"         // movsx   ebx,dword ptr [ebp+00]
+                        "\x85\xf6"                 // test    esi,esi
+                        "\x7f\x02"                 // jg      skip,+02
+                        "\x33\xf6"                 // xor     esi,esi
+                        "\xc3"                     // ret
+                        ;
+
+                    memcpy(cursor, code_put, sizeof(code_put) - 1);
+                    cursor += sizeof(code_put) - 1;
+                }
+            }
+
+            {
+                OverWriteOnProtectHelper h(GLOBAL::exedit_base + 0x0156f5, 6);
+                h.store_i16(0, '\x90\xe8');
+                h.replaceNearJmp(2, cursor);
+                /*
+                    100156f5 0fbf1f             movsx   ebx,dword ptr [edi]
+                    100156f8 0fbf2e             movsx   ebp,dword ptr [esi]
+
+                    ↓
+
+                    100156f5 90                 nop
+                    100156f6 e8XxXxXxXx         call    executable_memory_cursor
+
+                        ; ebx(pix->y)が0未満の場合、0にする
+                */
+                static const char code_put[] =
+                    "\x0f\xbf\x1f"             // movsx   ebx,dword ptr [edi]
+                    "\x0f\xbf\x2e"             // movsx   ebp,dword ptr [esi]
+                    "\x85\xdb"                 // test    ebx,ebx
+                    "\x7f\x02"                 // jg      skip,+02
+                    "\x33\xdb"                 // xor     ebx,ebx
+                    "\xc3"                     // ret
+                    ;
+
+                memcpy(cursor, code_put, sizeof(code_put) - 1);
+                cursor += sizeof(code_put) - 1;
+            }
+
+        }
+
+        void switching(bool flag) {
+            enabled = flag;
+        }
+
+        bool is_enabled() { return enabled; }
+        bool is_enabled_i() { return enabled_i; }
+
+        void switch_load(ConfigReader& cr) {
+            cr.regist(key, [this](json_value_s* value) {
+                ConfigReader::load_variable(value, enabled);
+                });
+        }
+
+        void switch_store(ConfigWriter& cw) {
+            cw.append(key, enabled);
+        }
+    } obj_specialcolorconv;
+} // namespace patch
+#endif // ifdef PATCH_SWITCH_OBJ_SPECIALCOLORCONV


### PR DESCRIPTION
0除算の代わりにどういう計算をするのがベストかが分かりませんでしたが、
pix->yが負の値になっている時、0にするように変更することで修正