### PR TITLE
レンズブラーのバグ修正2

### DIFF
--- a/patch.aul.txt
+++ b/patch.aul.txt
@@ -77,6 +77,7 @@ https://scrapbox.io/ePi5131/patch.aul
     ・アルファチャンネル有りシーンで合成モード「通常」以外を使用すると、他シーンで表示した時の結果が正しくないのを修正
     ・ファイルパスが原因の「対応していないフォーマット～」エラーのメッセージを変更する
     ・色調補正の色相計算を修正
+    ・範囲の大きいレンズブラーを掛けると危険な処理が行われるのを修正
 
     追加
     ・コンソールの表示
@@ -180,7 +181,7 @@ https://scrapbox.io/ePi5131/patch.aul
 		"exeditwindow_sizing" : boolean, ; 拡張編集ウィンドウの上部をドラッグして正常にリサイズできるようにする (既定値: true)
         "settingdialog_move" : boolean, ; 設定ダイアログを高ポーリングレートマウス環境で移動すると重たい の解消 (既定値: true)
 		"obj_colorcorrection" : boolean, ; 色調補正の色相計算を修正 (既定値: true)
-		"obj_lensblur" : boolean, ; 小さい画像に対してサイズ固定で範囲の大きいレンズブラーを掛けると例外になるのを修正 (既定値: true)
+		"obj_lensblur" : boolean, ; レンズブラーのバグ修正 (既定値: true)
 		"obj_noise" : boolean, ; ノイズの速度X、変化速度のトラック変化方法が移動無し以外の時に速度Yの値をもとに計算が行われてしまうのを修正 (既定値: true)
 		"settingdialog_excolorconfig" : boolean, ; 拡張色変換のウィンドウが下のフィルタに被るのを修正 (既定値: true)
 		"r_click_menu_split" : boolean, ; 右クリック分割で設定ダイアログが更新されないのを修正 (既定値: true)

--- a/patch/offset_address.hpp
+++ b/patch/offset_address.hpp
@@ -53,6 +53,9 @@ namespace OFS {
 		constexpr i32 exedit_max_h_add8 = 0x135c64;
 		constexpr i32 exedit_buffer_line = 0x135c68;
 
+		constexpr i32 exedit_YC_vram_w = 0x149840;
+		constexpr i32 exedit_YC_vram_h = 0x14ca4c;
+
 		constexpr i32 exedit_max_w = 0x196748;
 		constexpr i32 exedit_max_h = 0x1920e0;
 

--- a/patch/patch_obj_lensblur.cpp
+++ b/patch/patch_obj_lensblur.cpp
@@ -17,19 +17,148 @@
 
 #ifdef PATCH_SWITCH_OBJ_LENSBLUR
 namespace patch {
-	void* __cdecl obj_LensBlur_t::efLensBlur_resize_709a0_wrap_12809(void* pix_edit, int w0, int h0, int w1, int h1, void* pix_temp) {
+	void* __cdecl obj_LensBlur_t::lbResize_709a0_wrap_12809(void* pix_edit, int w0, int h0, int w1, int h1, void* pix_temp) {
 		if (w0 && h0 && w1 && h1) {
 			return reinterpret_cast<void* (__cdecl*)(void*, int, int, int, int, void*)>(GLOBAL::exedit_base + 0x0709a0)(pix_edit, w0, h0, w1, h1, pix_temp);
 		}
 		return pix_edit;
 	}
 
-	void* __cdecl obj_LensBlur_t::efLensBlur_resize_71420_wrap_126a6(void* pix_edit, int w0, int h0, int w1, int h1, void* pix_temp) {
+	void* __cdecl obj_LensBlur_t::lbResize_71420_wrap_126a6(void* pix_edit, int w0, int h0, int w1, int h1, void* pix_temp) {
 		if (w0 && h0 && w1 && h1) {
 			return reinterpret_cast<void* (__cdecl*)(void*, int, int, int, int, void*)>(GLOBAL::exedit_base + 0x071420)(pix_edit, w0, h0, w1, h1, pix_temp);
 		}
 		return pix_edit;
 	}
+
+
+	void __cdecl obj_LensBlur_t::lbResize_set_w_end(void* dst, void* src, int w, int h, int back) {
+		lbResize_wh_end = w - 1;
+	}
+	void __cdecl obj_LensBlur_t::lbResize_set_h_end(void* dst, void* src, int w, int h, int back) {
+		lbResize_wh_end = h - 1;
+	}
+
+
+
+
+	struct PixelYC_fbb {
+		float y;
+		byte cb;
+		byte cr;
+	};
+
+	void obj_LensBlur_t::lbResize_media(int thread_id, int thread_num, int loop1, int forstep1, int loop2, int forstep2, int flag) {
+		forstep1 *= sizeof(struct ExEdit::PixelYCA);
+		forstep2 *= sizeof(struct ExEdit::PixelYCA);
+		int i_end = (thread_id + 1) * loop1 / thread_num;
+		for (int i = thread_id * loop1 / thread_num; i < i_end; i++) {
+			int ii = lbresize->resize_step * i + (lbresize->resize_step - 0x10000) / 2;
+			int fraction = ii & 0xffff;
+			int inv_fraction = 0x10000 - fraction;
+			ii >>= 16;
+			auto dst = (ExEdit::PixelYCA*)((int)lbresize->resize_temp + i * forstep1);
+			auto src0 = (ExEdit::PixelYCA*)((int)lbresize->resize_edit + max(0, ii) * forstep1);
+			auto src1 = (ExEdit::PixelYCA*)((int)lbresize->resize_edit + min(ii + 1, lbResize_wh_end) * forstep1);
+
+			for (int j = 0; j < loop2; j++) {
+				int src0_a = (src0->a * inv_fraction + 0x800) >> 12;
+				int src1_a = (src1->a * fraction + 0x800) >> 12;
+				int a = src0_a + src1_a;
+				if (a <= 0) {
+					dst->y = dst->cb = dst->cr = dst->a = 0;
+				} else {
+					if (flag) {
+						((PixelYC_fbb*)dst)->y = (((PixelYC_fbb*)src0)->y * (float)src0_a + ((PixelYC_fbb*)src1)->y * (float)src1_a) / (float)a;
+						((PixelYC_fbb*)dst)->cb = (byte)((((PixelYC_fbb*)src0)->cb * src0_a + ((PixelYC_fbb*)src1)->cb * src1_a) / a);
+						((PixelYC_fbb*)dst)->cr = (byte)((((PixelYC_fbb*)src0)->cr * src0_a + ((PixelYC_fbb*)src1)->cr * src1_a) / a);
+					} else {
+						dst->y = (short)((src0->y * src0_a + src1->y * src1_a) / a);
+						dst->cb = (short)((src0->cb * src0_a + src1->cb * src1_a) / a);
+						dst->cr = (short)((src0->cr * src0_a + src1->cr * src1_a) / a);
+					}
+					dst->a = (short)((a + 8) >> 4);
+				}
+				dst = (ExEdit::PixelYCA*)((int)dst + forstep2);
+				src0 = (ExEdit::PixelYCA*)((int)src0 + forstep2);
+				src1 = (ExEdit::PixelYCA*)((int)src1 + forstep2);
+			}
+		}
+	}
+
+
+	void obj_LensBlur_t::lbResize_filter(int thread_id, int thread_num, int loop1, int forstep1, int loop2, int forstep2, int flag) {
+		forstep1 *= sizeof(struct AviUtl::PixelYC);
+		forstep2 *= sizeof(struct AviUtl::PixelYC);
+		int i_end = (thread_id + 1) * loop1 / thread_num;
+		for (int i = thread_id * loop1 / thread_num; i < i_end; i++) {
+			int ii = lbresize->resize_step * i + (lbresize->resize_step - 0x10000) / 2;
+			int fraction = ii & 0xffff;
+			int inv_fraction = 0x10000 - fraction;
+			ii >>= 16;
+			auto dst = (AviUtl::PixelYC*)((int)lbresize->resize_temp + i * forstep1);
+			auto src0 = (AviUtl::PixelYC*)((int)lbresize->resize_edit + max(0, ii) * forstep1);
+			auto src1 = (AviUtl::PixelYC*)((int)lbresize->resize_edit + min(ii + 1, lbResize_wh_end) * forstep1);
+
+			for (int j = 0; j < loop2; j++) {
+				if (flag) {
+					((PixelYC_fbb*)dst)->y = (((PixelYC_fbb*)src0)->y * (float)inv_fraction + ((PixelYC_fbb*)src1)->y * (float)fraction) / 65536.0f;
+					((PixelYC_fbb*)dst)->cb = (byte)((((PixelYC_fbb*)src0)->cb * inv_fraction + ((PixelYC_fbb*)src1)->cb * fraction + 0x8000) >> 16);
+					((PixelYC_fbb*)dst)->cr = (byte)((((PixelYC_fbb*)src0)->cr * inv_fraction + ((PixelYC_fbb*)src1)->cr * fraction + 0x8000) >> 16);
+				} else {
+					dst->y = (short)((src0->y * inv_fraction + src1->y * fraction + 0x8000) >> 16);
+					dst->cb = (short)((src0->cb * inv_fraction + src1->cb * fraction + 0x8000) >> 16);
+					dst->cr = (short)((src0->cr * inv_fraction + src1->cr * fraction + 0x8000) >> 16);
+				}
+				dst = (AviUtl::PixelYC*)((int)dst + forstep2);
+				src0 = (AviUtl::PixelYC*)((int)src0 + forstep2);
+				src1 = (AviUtl::PixelYC*)((int)src1 + forstep2);
+			}
+		}
+	}
+
+
+	void __cdecl obj_LensBlur_t::lbResize_media_interpolation_y(int thread_id, int thread_num, void* n1, void* n2) {
+		// exedit + 70df0 相当
+		int exedit_buffer_line = *(int*)(GLOBAL::exedit_base + OFS::ExEdit::exedit_buffer_line);
+		lbResize_media(thread_id, thread_num, lbresize->resize_h, exedit_buffer_line, lbresize->resize_w, 1, 0);
+	}
+	void __cdecl obj_LensBlur_t::lbResize_media_interpolation_x(int thread_id, int thread_num, void* n1, void* n2) {
+		// exedit + 71270 相当
+		int exedit_buffer_line = *(int*)(GLOBAL::exedit_base + OFS::ExEdit::exedit_buffer_line);
+		lbResize_media(thread_id, thread_num, lbresize->resize_w, 1, lbresize->resize_h, exedit_buffer_line, 0);
+	}
+	void __cdecl obj_LensBlur_t::lbResize_media_interpolation_y_fbb(int thread_id, int thread_num, void* n1, void* n2) {
+		// exedit + 71870 相当
+		int exedit_buffer_line = *(int*)(GLOBAL::exedit_base + OFS::ExEdit::exedit_buffer_line);
+		lbResize_media(thread_id, thread_num, lbresize->resize_h, exedit_buffer_line, lbresize->resize_w, 1, 1);
+	}
+	void __cdecl obj_LensBlur_t::lbResize_media_interpolation_x_fbb(int thread_id, int thread_num, void* n1, void* n2) {
+		// exedit + 71ce0 相当
+		int exedit_buffer_line = *(int*)(GLOBAL::exedit_base + OFS::ExEdit::exedit_buffer_line);
+		lbResize_media(thread_id, thread_num, lbresize->resize_w, 1, lbresize->resize_h, exedit_buffer_line, 1);
+	}
+	void __cdecl obj_LensBlur_t::lbResize_filter_interpolation_y(int thread_id, int thread_num, void* n1, void* n2) {
+		// exedit + 72390 相当
+		int si_vram_w = *(int*)(GLOBAL::exedit_base + OFS::ExEdit::exedit_YC_vram_w);
+		lbResize_filter(thread_id, thread_num, lbresize->resize_h, si_vram_w, lbresize->resize_w, 1, 0);
+	}
+	void __cdecl obj_LensBlur_t::lbResize_filter_interpolation_x(int thread_id, int thread_num, void* n1, void* n2) {
+		// exedit + 72720 相当
+		int si_vram_w = *(int*)(GLOBAL::exedit_base + OFS::ExEdit::exedit_YC_vram_w);
+		lbResize_filter(thread_id, thread_num, lbresize->resize_w, 1, lbresize->resize_h, si_vram_w, 0);
+	}
+	void __cdecl obj_LensBlur_t::lbResize_filter_interpolation_y_fbb(int thread_id, int thread_num, void* n1, void* n2) {
+		// exedit + 72c20 相当
+		int si_vram_w = *(int*)(GLOBAL::exedit_base + OFS::ExEdit::exedit_YC_vram_w);
+		lbResize_filter(thread_id, thread_num, lbresize->resize_h, si_vram_w, lbresize->resize_w, 1, 1);
+	}
+	void __cdecl obj_LensBlur_t::lbResize_filter_interpolation_x_fbb(int thread_id, int thread_num, void* n1, void* n2) {
+		// exedit + 72f90 相当
+		int si_vram_w = *(int*)(GLOBAL::exedit_base + OFS::ExEdit::exedit_YC_vram_w);
+		lbResize_filter(thread_id, thread_num, lbresize->resize_w, 1, lbresize->resize_h, si_vram_w, 1);
+	}
+
 
 } // namespace patch
 #endif // ifdef PATCH_SWITCH_OBJ_LENSBLUR

--- a/patch/patch_obj_lensblur.hpp
+++ b/patch/patch_obj_lensblur.hpp
@@ -34,22 +34,120 @@ namespace patch {
         サイズ固定にチェックが入った状態でレンズブラー範囲を広げる
     */
 
+    /* オフセットアドレス exedit + 71f95 の修正
+        フィルタオブジェクトのレンズブラー(範囲を広げたもの)をシーンオブジェクトで読み込む
+        シーンオブジェクト以外でエラーはあまり見られないけど他データを破壊していそうなのでそちらもまとめて修正
+    */
+
     inline class obj_LensBlur_t {
 
-        static void* efLensBlur_resize_709a0_wrap_12809(void* pix_edit, int w0, int h0, int w1, int h1, void* pix_temp);
-        static void* efLensBlur_resize_71420_wrap_126a6(void* pix_edit, int w0, int h0, int w1, int h1, void* pix_temp);
+        static void* __cdecl lbResize_709a0_wrap_12809(void* pix_edit, int w0, int h0, int w1, int h1, void* pix_temp);
+        static void* __cdecl lbResize_71420_wrap_126a6(void* pix_edit, int w0, int h0, int w1, int h1, void* pix_temp);
+
+
+
+        inline static struct lbResize_var { // 1e42c0
+            void* resize_edit;
+            int _others1[8];
+            void* resize_temp; // 1e42e4
+            int _others2[14];
+            int resize_step; // 1e4320
+            int resize_h; // 1e4324
+            int _bufcpy_h; // 1e4328
+            int resize_w; // 1e432c
+        }*lbresize;
+
+        inline static int lbResize_wh_end;
+
+        static void __cdecl lbResize_set_w_end(void* dst, void* src, int w, int h, int back);
+        static void __cdecl lbResize_set_h_end(void* dst, void* src, int w, int h, int back);
+
+        static void lbResize_media(int thread_id, int thread_num, int loop1, int forstep1, int loop2, int forstep2, int flag);
+        static void lbResize_filter(int thread_id, int thread_num, int loop1, int forstep1, int loop2, int forstep2, int flag);
+
+        static void __cdecl lbResize_media_interpolation_y(int thread_id, int thread_num, void* n1, void* n2);
+        static void __cdecl lbResize_media_interpolation_x(int thread_id, int thread_num, void* n1, void* n2);
+        static void __cdecl lbResize_media_interpolation_y_fbb(int thread_id, int thread_num, void* n1, void* n2);
+        static void __cdecl lbResize_media_interpolation_x_fbb(int thread_id, int thread_num, void* n1, void* n2);
+        static void __cdecl lbResize_filter_interpolation_y(int thread_id, int thread_num, void* n1, void* n2);
+        static void __cdecl lbResize_filter_interpolation_x(int thread_id, int thread_num, void* n1, void* n2);
+        static void __cdecl lbResize_filter_interpolation_y_fbb(int thread_id, int thread_num, void* n1, void* n2);
+        static void __cdecl lbResize_filter_interpolation_x_fbb(int thread_id, int thread_num, void* n1, void* n2);
+
+
         bool enabled = true;
         bool enabled_i;
         inline static const char key[] = "obj_lensblur";
     public:
+
+
         void init() {
             enabled_i = enabled;
 
             if (!enabled_i)return;
 
-            // オフセットアドレス exedit + 71449 の修正
-            ReplaceNearJmp(GLOBAL::exedit_base + 0x01280a, &efLensBlur_resize_709a0_wrap_12809);
-            ReplaceNearJmp(GLOBAL::exedit_base + 0x0126a7, &efLensBlur_resize_71420_wrap_126a6);
+            { // オフセットアドレス exedit + 71449 の修正
+                ReplaceNearJmp(GLOBAL::exedit_base + 0x01280a, &lbResize_709a0_wrap_12809);
+                ReplaceNearJmp(GLOBAL::exedit_base + 0x0126a7, &lbResize_71420_wrap_126a6);
+            }
+
+            
+            { // オフセットアドレス exedit + 71f95 の修正、なんかやヴぁそうなバグの修正
+
+                /* 以下の関数にて行われる危険な処理：memcpy( &ycp_edit[-line_size-1], &ycp_edit[-1], (line_size+2) * sizeof(PIXEL_YC));
+                    おそらく補間処理を行うための前処理として行われている
+                    危険なのでその前処理は全て削除し、ついでにリサイズ前のw,hを取得したいので置き換える
+                */
+                ReplaceNearJmp(GLOBAL::exedit_base + 0x070a08, &lbResize_set_h_end);
+                ReplaceNearJmp(GLOBAL::exedit_base + 0x070aab, &lbResize_set_w_end);
+                ReplaceNearJmp(GLOBAL::exedit_base + 0x071488, &lbResize_set_h_end);
+                ReplaceNearJmp(GLOBAL::exedit_base + 0x07152b, &lbResize_set_w_end);
+                ReplaceNearJmp(GLOBAL::exedit_base + 0x072068, &lbResize_set_h_end);
+                ReplaceNearJmp(GLOBAL::exedit_base + 0x07210b, &lbResize_set_w_end);
+                ReplaceNearJmp(GLOBAL::exedit_base + 0x0728d8, &lbResize_set_h_end);
+                ReplaceNearJmp(GLOBAL::exedit_base + 0x07297b, &lbResize_set_w_end);
+
+                lbresize = (lbResize_var*)(GLOBAL::exedit_base + 0x1e42c0);
+
+                /* 前処理が無くても同じように動くように書いたものに置き換える
+                    リソースのことを考えて関数はできるだけ纏めた
+                    x方向の処理が従来より効率が良いのでそんなに速度が落ちることは無いはず
+                */
+                {
+                    OverWriteOnProtectHelper h(GLOBAL::exedit_base + 0x070a3f, 4);
+                    h.store_i32(0, &lbResize_media_interpolation_y);
+                }
+                {
+                    OverWriteOnProtectHelper h(GLOBAL::exedit_base + 0x070ac5, 4);
+                    h.store_i32(0, &lbResize_media_interpolation_x);
+                }
+                {
+                    OverWriteOnProtectHelper h(GLOBAL::exedit_base + 0x0714bf, 4);
+                    h.store_i32(0, &lbResize_media_interpolation_y_fbb);
+                }
+                {
+                    OverWriteOnProtectHelper h(GLOBAL::exedit_base + 0x071545, 4);
+                    h.store_i32(0, &lbResize_media_interpolation_x_fbb);
+                }
+                {
+                    OverWriteOnProtectHelper h(GLOBAL::exedit_base + 0x07209f, 4);
+                    h.store_i32(0, &lbResize_filter_interpolation_y);
+                }
+                {
+                    OverWriteOnProtectHelper h(GLOBAL::exedit_base + 0x072125, 4);
+                    h.store_i32(0, &lbResize_filter_interpolation_x);
+                }
+                {
+                    OverWriteOnProtectHelper h(GLOBAL::exedit_base + 0x07290f, 4);
+                    h.store_i32(0, &lbResize_filter_interpolation_y_fbb);
+                }
+                {
+                    OverWriteOnProtectHelper h(GLOBAL::exedit_base + 0x072995, 4);
+                    h.store_i32(0, &lbResize_filter_interpolation_x_fbb);
+                }
+
+
+            }
 
         }
 


### PR DESCRIPTION
1があったので2もあるのだ

オフセットアドレス71f95の条件：
シーンにフィルタオブジェクトのレンズブラーを置き、レンズブラー範囲を大きくしてシーンオブジェクトから読み込む

それ以外でも、レンズブラー範囲が大きい時には他データを破壊している可能性がある