### PR TITLE
patch.undoにて中間点ありオブジェクトを上手く扱えていなかったのを修正

### DIFF
--- a/patch/offset_address.hpp
+++ b/patch/offset_address.hpp
@@ -152,6 +152,7 @@ namespace OFS {
 		constexpr i32 specialcolorconv_status2 = 0x0a14f4;
 
 		constexpr i32 ObjectArrayPointer = 0x1e0fa4;
+		constexpr i32 NextObjectIdxArray = 0x1592d8;
 
 		constexpr i32 ScaleColorBackGround = 0x0a4048;
 		constexpr i32 ScaleColorForeGround = 0x0a404c;

--- a/patch/patch_undo.cpp
+++ b/patch/patch_undo.cpp
@@ -93,8 +93,17 @@ namespace patch {
         };
 
         if (*timeline_obj_click_mode_ptr == 2 || (*timeline_obj_click_mode_ptr == 3 && (*timeline_edit_both_adjacent_ptr & 1))) { // 左端 || (右端 && 環境設定の隣接するオブジェクトも選択がON )
-            if (exists_movable_playback_pos(object_idx)) {
-                set_undo(object_idx, 0);
+            auto eop = &(*ObjectArrayPointer_ptr)[object_idx];
+            int obj_idx = eop->index_midpt_leader;
+            if (obj_idx == -1 || obj_idx == object_idx) {
+                if (exists_movable_playback_pos(object_idx)) {
+                    obj_idx = object_idx;
+                    while (0 <= obj_idx) {
+                        set_undo(obj_idx, 0);
+                        obj_idx = NextObjectIdxArray[obj_idx];
+                    }
+                    return;
+                }
             }
         }
         set_undo(object_idx, flag);

--- a/patch/patch_undo.cpp
+++ b/patch/patch_undo.cpp
@@ -95,9 +95,13 @@ namespace patch {
         if (*timeline_obj_click_mode_ptr == 2 || (*timeline_obj_click_mode_ptr == 3 && (*timeline_edit_both_adjacent_ptr & 1))) { // 左端 || (右端 && 環境設定の隣接するオブジェクトも選択がON )
             auto eop = &(*ObjectArrayPointer_ptr)[object_idx];
             int obj_idx = eop->index_midpt_leader;
-            if (obj_idx == -1 || obj_idx == object_idx) {
+            if (obj_idx == -1) {
                 if (exists_movable_playback_pos(object_idx)) {
-                    obj_idx = object_idx;
+                    set_undo(object_idx, 0);
+                    return;
+                }
+            } else if (obj_idx == object_idx) {
+                if (exists_movable_playback_pos(obj_idx)) {
                     while (0 <= obj_idx) {
                         set_undo(obj_idx, 0);
                         obj_idx = NextObjectIdxArray[obj_idx];

--- a/patch/patch_undo.hpp
+++ b/patch/patch_undo.hpp
@@ -31,6 +31,7 @@ namespace patch {
     inline class undo_t {
 
         inline static ExEdit::Object** ObjectArrayPointer_ptr;
+        inline static int* NextObjectIdxArray;
         inline static ExEdit::LayerSetting** layer_setting_ofsptr_ptr;
         inline static void** exdata_buffer_ptr;
         inline static int* timeline_obj_click_mode_ptr;
@@ -120,6 +121,7 @@ namespace patch {
             if (!enabled_i) return;
 
             ObjectArrayPointer_ptr = reinterpret_cast<decltype(ObjectArrayPointer_ptr)>(GLOBAL::exedit_base + OFS::ExEdit::ObjectArrayPointer);
+            NextObjectIdxArray = reinterpret_cast<int*>(GLOBAL::exedit_base + OFS::ExEdit::NextObjectIdxArray);
             layer_setting_ofsptr_ptr = reinterpret_cast<decltype(layer_setting_ofsptr_ptr)>(GLOBAL::exedit_base + 0x0a4058);
             exdata_buffer_ptr = reinterpret_cast<void**>(GLOBAL::exedit_base + 0x1e0fa8);
             timeline_obj_click_mode_ptr = reinterpret_cast<int*>(GLOBAL::exedit_base + 0x177a24);


### PR DESCRIPTION
元に戻すのバグ修正 [オブジェクトの左端をつまんで動かすと再生位置パラメータが変わるが、それが元に戻らない の修正] のバグを修正

中間点ありオブジェクトの先頭以外のObject.exdata_offsetは0となるのが仕様のようで、先頭から参照しなければならない
これをせずに0として最初のオブジェクトのexdataから参照してバグることがあった

ついでに先頭以外のオブジェクトの再生位置パラメータが戻らない状態だったため修正