### PR TITLE
シーン画像生成に時間がかかった時にキャッシュを作成する

### DIFF
--- a/patch.aul.txt
+++ b/patch.aul.txt
@@ -92,6 +92,7 @@ https://scrapbox.io/ePi5131/patch.aul
     ・レイヤー情報を保存するかどうかの判定方法を変える(従来:オブジェクトが存在する→変更:レイヤー情報が初期値でない)
     ・読み込もうとしたファイルパスが長くて失敗するときにメッセージを出す/エラーが発生するのを修正
     ・ドロップ処理で最終的に何も行われなかったときにメッセージを出力する
+    ・シーン画像生成に時間がかかった時にキャッシュを作成する機能の追加
 
     追加
     ・コンソールの表示
@@ -216,6 +217,7 @@ https://scrapbox.io/ePi5131/patch.aul
 		"add_extension" : boolean, ; 動画、音声ファイル参照の時、exedit.iniにある拡張子を追加する (既定値: true)
 		"new_project_editbox" : boolean, ; 新規プロジェクト作成ダイアログの画像サイズ入力欄の幅を広げる (既定値: true)
 		"playback_speed" : boolean, ; 中間点で再生速度を変更した時、そこまでの中間点の数だけ速度変化が遅れて反映されるバグの修正 (既定値: true)
+		"scene_cache" : boolean, ; シーン画像生成に時間がかかった時にキャッシュを作成する機能の追加 (既定値: true)
         "undo" : boolean, ; 元に戻す 関連のバグ修正 (既定値: true)
         "undo.redo" : boolean, ; やり直す を追加 (既定値: true)
 		"console" : boolean, ; コンソール (既定値: true)

--- a/patch/config.hpp
+++ b/patch/config.hpp
@@ -182,6 +182,9 @@ public:
             #ifdef PATCH_SWITCH_PLAYBACK_SPEED
                 patch::playback_speed.switch_load(cr);
             #endif
+            #ifdef PATCH_SWITCH_SCENE_CACHE
+                patch::scene_cache.switch_load(cr);
+            #endif
 		
 		    #ifdef PATCH_SWITCH_UNDO
                 patch::undo.switch_load(cr);
@@ -510,6 +513,9 @@ public:
             #endif
             #ifdef PATCH_SWITCH_PLAYBACK_SPEED
                 patch::playback_speed.switch_store(switch_);
+            #endif
+            #ifdef PATCH_SWITCH_SCENE_CACHE
+                patch::scene_cache.switch_store(switch_);
             #endif
 
 		    #ifdef PATCH_SWITCH_UNDO

--- a/patch/init.cpp
+++ b/patch/init.cpp
@@ -225,6 +225,9 @@ void init_t::InitAtExeditLoad() {
 #ifdef PATCH_SWITCH_PLAYBACK_SPEED
 	patch::playback_speed.init();
 #endif
+#ifdef PATCH_SWITCH_SCENE_CACHE
+	patch::scene_cache.init();
+#endif
 	
 	patch::setting_dialog();
 

--- a/patch/macro.h
+++ b/patch/macro.h
@@ -137,6 +137,7 @@
 #define PATCH_SWITCH_DIALOG_NEW_FILE dlg_newfile
 #define PATCH_SWITCH_PLAYBACK_SPEED pb_speed
 #define PATCH_SWITCH_SETTING_NEW_PROJECT setting_newproject
+#define PATCH_SWITCH_SCENE_CACHE scenecache
 
 #define PATCH_SWITCH_UNDO undo
 #ifdef PATCH_SWITCH_UNDO

--- a/patch/offset_address.hpp
+++ b/patch/offset_address.hpp
@@ -71,6 +71,9 @@ namespace OFS {
 		constexpr i32 exedit_max_h = 0x1920e0;
 
 		constexpr i32 memory_ptr = 0x01a5328;
+		
+		constexpr i32 fast_process = 0x2308a0;
+		constexpr i32 is_saving = 0x1a52e4;
 
 		constexpr i32 CreateFigure_var_ptr = 0x1e4798;
 		constexpr i32 CreateFigure_circle_func_call = 0x073882;

--- a/patch/offset_address.hpp
+++ b/patch/offset_address.hpp
@@ -25,6 +25,7 @@ namespace OFS {
 		constexpr i32 current_resource_hmod = 0x2d910c;
 		constexpr i32 edit_handle_ptr = 0x08717c;
 		constexpr i32 saveProjectFile = 0x024160;
+		constexpr i32 exfunc = 0x0a8c78;
 		
 		constexpr i32 str_dot_avi = 0x0745fc; // ".avi"
 		
@@ -106,6 +107,11 @@ namespace OFS {
 		constexpr i32 str_DOUGAFILE = 0x09df6c; // "動画ファイル"
 		constexpr i32 str_ONSEIFILE = 0x0ba698; // "音声ファイル"
 
+		constexpr i32 SceneDisplaying = 0x1a5310;
+		constexpr i32 SceneSetting = 0x177a50;
+		constexpr i32 get_scene_image = 0x04ce20;
+		constexpr i32 get_scene_size = 0x02b980;
+		constexpr i32 scene_has_alpha = 0x02ba00;
 		
 		constexpr i32 exedit_edit_open = 0x03ac30;
 

--- a/patch/patch.hpp
+++ b/patch/patch.hpp
@@ -83,3 +83,4 @@
 #include "patch_aup_layer_setting.hpp"
 #include "patch_failed_file_drop.hpp"
 #include "patch_failed_longer_path.hpp"
+#include "patch_scene_cache.hpp"

--- a/patch/patch_scene_cache.cpp
+++ b/patch/patch_scene_cache.cpp
@@ -36,7 +36,7 @@ namespace patch {
 		if (img_ptr == NULL) {
 			return NULL;
 		}
-		if (64 < GetTickCount() - t0) {
+		if (time_shreshold < GetTickCount() - t0) {
 			int yc_size, flag;
 			if (reinterpret_cast<BOOL(__cdecl*)(int)>(GLOBAL::exedit_base + OFS::ExEdit::scene_has_alpha)(scene_idx)) {
 				yc_size = 8;

--- a/patch/patch_scene_cache.cpp
+++ b/patch/patch_scene_cache.cpp
@@ -1,0 +1,65 @@
+/*
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "patch_scene_cache.hpp"
+
+#ifdef PATCH_SWITCH_SCENE_CACHE
+namespace patch {
+
+	void* __cdecl scene_cache_t::get_scene_image_wrap(ExEdit::ObjectFilterIndex ofi, ExEdit::FilterProcInfo* efpip, int scene_idx, int frame, int subframe, int* w, int* h) {
+		int* SceneDisplaying = (int*)(GLOBAL::exedit_base + OFS::ExEdit::SceneDisplaying);
+		if (*SceneDisplaying != 0) {
+			return get_scene_image(ofi, efpip, scene_idx, frame, subframe, w, h);
+		}
+
+		auto a_exfunc = (AviUtl::ExFunc*)(GLOBAL::aviutl_base + OFS::AviUtl::exfunc);
+
+		void* smem_ptr = a_exfunc->get_shared_mem((int)&get_scene_image + scene_idx, (frame << 7) | subframe, NULL);
+		if (smem_ptr != NULL) {
+			reinterpret_cast<void(__cdecl*)(int, int*, int*, ExEdit::FilterProcInfo*)>(GLOBAL::exedit_base + OFS::ExEdit::get_scene_size)(scene_idx, w, h, efpip);
+			return smem_ptr;
+		}
+		int t0 = GetTickCount();
+		void* img_ptr = get_scene_image(ofi, efpip, scene_idx, frame, subframe, w, h);
+		if (img_ptr == NULL) {
+			return NULL;
+		}
+		if (64 < GetTickCount() - t0) {
+			int yc_size, flag;
+			if (reinterpret_cast<BOOL(__cdecl*)(int)>(GLOBAL::exedit_base + OFS::ExEdit::scene_has_alpha)(scene_idx)) {
+				yc_size = 8;
+				flag = 0x13000003;
+			} else {
+				yc_size = 6;
+				flag = 0x13000002;
+			}
+			void* smem_ptr = a_exfunc->create_shared_mem((int)&get_scene_image + scene_idx, (frame << 7) | subframe, efpip->scene_line * *h * yc_size, NULL);
+			if (smem_ptr == NULL) {
+				return img_ptr;
+			}
+			memcpy(smem_ptr, img_ptr, efpip->scene_line * *h * yc_size);
+		}
+		return img_ptr;
+	}
+	void scene_cache_t::delete_scene_cache() {
+		auto a_exfunc = (AviUtl::ExFunc*)(GLOBAL::aviutl_base + OFS::AviUtl::exfunc);
+		for (int i = 1; i < 50; i++) {
+			a_exfunc->delete_shared_mem((int)&get_scene_image + i, NULL);
+		}
+	}
+
+
+} // namespace patch
+#endif // ifdef PATCH_SWITCH_SCENE_CACHE

--- a/patch/patch_scene_cache.cpp
+++ b/patch/patch_scene_cache.cpp
@@ -23,10 +23,19 @@ namespace patch {
 		if (*SceneDisplaying != 0) {
 			return get_scene_image(ofi, efpip, scene_idx, frame, subframe, w, h);
 		}
-
+		
 		auto a_exfunc = (AviUtl::ExFunc*)(GLOBAL::aviutl_base + OFS::AviUtl::exfunc);
 
-		void* smem_ptr = a_exfunc->get_shared_mem((int)&get_scene_image + scene_idx, (frame << 7) | subframe, NULL);
+
+		int key = *(int*)(GLOBAL::exedit_base + OFS::ExEdit::is_saving);
+		if (key) {
+			key <<= 6;
+		} else {
+			key = *(int*)(GLOBAL::exedit_base + OFS::ExEdit::fast_process) << 7;
+		}
+		key += (int)&get_scene_image + scene_idx;
+
+		void* smem_ptr = a_exfunc->get_shared_mem(key, (frame << 7) | subframe, NULL);
 		if (smem_ptr != NULL) {
 			reinterpret_cast<void(__cdecl*)(int, int*, int*, ExEdit::FilterProcInfo*)>(GLOBAL::exedit_base + OFS::ExEdit::get_scene_size)(scene_idx, w, h, efpip);
 			return smem_ptr;
@@ -45,7 +54,7 @@ namespace patch {
 				yc_size = 6;
 				flag = 0x13000002;
 			}
-			void* smem_ptr = a_exfunc->create_shared_mem((int)&get_scene_image + scene_idx, (frame << 7) | subframe, efpip->scene_line * *h * yc_size, NULL);
+			void* smem_ptr = a_exfunc->create_shared_mem(key, (frame << 7) | subframe, efpip->scene_line * *h * yc_size, NULL);
 			if (smem_ptr == NULL) {
 				return img_ptr;
 			}
@@ -55,8 +64,11 @@ namespace patch {
 	}
 	void scene_cache_t::delete_scene_cache() {
 		auto a_exfunc = (AviUtl::ExFunc*)(GLOBAL::aviutl_base + OFS::AviUtl::exfunc);
-		for (int i = 1; i < 50; i++) {
-			a_exfunc->delete_shared_mem((int)&get_scene_image + i, NULL);
+		for (int flag = 0; flag < 3; flag++) {
+			int key = (int)&get_scene_image + (flag << 6);
+			for (int i = 1; i < 50; i++) {
+				a_exfunc->delete_shared_mem(key + i, NULL);
+			}
 		}
 	}
 

--- a/patch/patch_scene_cache.hpp
+++ b/patch/patch_scene_cache.hpp
@@ -28,6 +28,7 @@ namespace patch {
 
     // init at exedit load
     // Rootで取得した場合のみシーンのキャッシュをとる
+    // 仕様：シーンの画像構成に掛かった時間が64msを超えた時にキャッシュを生成する。シーンを切り替えた時点でキャッシュは破棄されます。
 
     inline class scene_cache_t {
 
@@ -36,6 +37,8 @@ namespace patch {
 
         inline static void* (__cdecl* get_scene_image)(ExEdit::ObjectFilterIndex, ExEdit::FilterProcInfo*, int, int, int, int*, int*);
 
+        inline static unsigned int time_shreshold = 64;
+        
         bool enabled = true;
         bool enabled_i;
         inline static const char key[] = "scene_cache";

--- a/patch/patch_scene_cache.hpp
+++ b/patch/patch_scene_cache.hpp
@@ -1,0 +1,87 @@
+/*
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+#include "macro.h"
+
+#ifdef PATCH_SWITCH_SCENE_CACHE
+
+#include <exedit.hpp>
+
+#include "global.hpp"
+#include "offset_address.hpp"
+#include "util.hpp"
+
+#include "config_rw.hpp"
+
+namespace patch {
+
+    // init at exedit load
+    // Rootで取得した場合のみシーンのキャッシュをとる
+
+    inline class scene_cache_t {
+
+        static void* __cdecl get_scene_image_wrap(ExEdit::ObjectFilterIndex ofi, ExEdit::FilterProcInfo* efpip, int scene_idx, int frame, int subframe, int* w, int* h);
+        static void delete_scene_cache();
+
+        inline static void* (__cdecl* get_scene_image)(ExEdit::ObjectFilterIndex, ExEdit::FilterProcInfo*, int, int, int, int*, int*);
+
+        bool enabled = true;
+        bool enabled_i;
+        inline static const char key[] = "scene_cache";
+    public:
+
+        void init() {
+            enabled_i = enabled;
+
+            if (!enabled_i)return;
+
+            get_scene_image = reinterpret_cast<decltype(get_scene_image)>(GLOBAL::exedit_base + OFS::ExEdit::get_scene_image);
+
+            {   // scene_obj
+                OverWriteOnProtectHelper h(GLOBAL::exedit_base + 0x0835bd, 4);
+                h.replaceNearJmp(0, &get_scene_image_wrap);
+            }
+            /*
+            {   // mask
+                OverWriteOnProtectHelper h(GLOBAL::exedit_base + 0x068a2d, 4);
+                h.replaceNearJmp(0, &get_scene_image_wrap);
+            }*/
+
+            {   // シーン切り替え時に初期化
+                OverWriteOnProtectHelper h(GLOBAL::exedit_base + 0x02be77, 5);
+                h.store_i8(0, '\xe9'); // jmp
+                h.replaceNearJmp(1, &delete_scene_cache);
+            }
+        }
+
+        void switching(bool flag) {
+            enabled = flag;
+        }
+
+        bool is_enabled() { return enabled; }
+        bool is_enabled_i() { return enabled_i; }
+
+        void switch_load(ConfigReader& cr) {
+            cr.regist(key, [this](json_value_s* value) {
+                ConfigReader::load_variable(value, enabled);
+                });
+        }
+
+        void switch_store(ConfigWriter& cw) {
+            cw.append(key, enabled);
+        }
+    } scene_cache;
+} // namespace patch
+
+#endif // ifdef PATCH_SWITCH_SCENE_CACHE


### PR DESCRIPTION
**変更点**
Rootからシーン画像生成に掛かった時間が64msを超えた時に共有メモリにキャッシュを保存し、次に同じフレームを読み込むときにはキャッシュから読み込んで高速化する。
シーンの切り替えが行われると全てのキャッシュは破棄されます。

**内容の精査**
以下の点について教えてください。
- [△] コードにおかしな点がないことを確認しました。
- [△] 実際にビルドして試しました。
※test版環境にてビルドして試しましたが、このブランチ内容でのビルドはしていません
https://github.com/nazonoSAUNA/aviutl_exedit_sdk/tree/iroiro への更新が必要です(プルリク済み)

