### PR TITLE
改行のみのテキストと一部スクリプトの組み合わせでエラーとなる

### DIFF
--- a/patch.aul.txt
+++ b/patch.aul.txt
@@ -92,6 +92,7 @@ https://scrapbox.io/ePi5131/patch.aul
     ・レイヤー情報を保存するかどうかの判定方法を変える(従来:オブジェクトが存在する→変更:レイヤー情報が初期値でない)
     ・読み込もうとしたファイルパスが長くて失敗するときにメッセージを出す/エラーが発生するのを修正
     ・ドロップ処理で最終的に何も行われなかったときにメッセージを出力する
+    ・改行のみのテキストで一部スクリプトを使うとエラーが発生するのを修正
 
     追加
     ・コンソールの表示
@@ -216,6 +217,7 @@ https://scrapbox.io/ePi5131/patch.aul
 		"add_extension" : boolean, ; 動画、音声ファイル参照の時、exedit.iniにある拡張子を追加する (既定値: true)
 		"new_project_editbox" : boolean, ; 新規プロジェクト作成ダイアログの画像サイズ入力欄の幅を広げる (既定値: true)
 		"playback_speed" : boolean, ; 中間点で再生速度を変更した時、そこまでの中間点の数だけ速度変化が遅れて反映されるバグの修正 (既定値: true)
+		"yc_rgb_conv" : boolean, ; 改行のみのテキストで一部スクリプトを使うとエラーが発生するのを修正 (既定値: true)
         "undo" : boolean, ; 元に戻す 関連のバグ修正 (既定値: true)
         "undo.redo" : boolean, ; やり直す を追加 (既定値: true)
 		"console" : boolean, ; コンソール (既定値: true)

--- a/patch/config.hpp
+++ b/patch/config.hpp
@@ -182,6 +182,9 @@ public:
             #ifdef PATCH_SWITCH_PLAYBACK_SPEED
                 patch::playback_speed.switch_load(cr);
             #endif
+            #ifdef PATCH_SWITCH_YC_RGB_CONV
+                patch::yc_rgb_conv.switch_load(cr);
+            #endif
 		
 		    #ifdef PATCH_SWITCH_UNDO
                 patch::undo.switch_load(cr);
@@ -510,6 +513,9 @@ public:
             #endif
             #ifdef PATCH_SWITCH_PLAYBACK_SPEED
                 patch::playback_speed.switch_store(switch_);
+            #endif
+            #ifdef PATCH_SWITCH_YC_RGB_CONV
+                patch::yc_rgb_conv.switch_store(switch_);
             #endif
 
 		    #ifdef PATCH_SWITCH_UNDO

--- a/patch/init.cpp
+++ b/patch/init.cpp
@@ -225,6 +225,9 @@ void init_t::InitAtExeditLoad() {
 #ifdef PATCH_SWITCH_PLAYBACK_SPEED
 	patch::playback_speed.init();
 #endif
+#ifdef PATCH_SWITCH_YC_RGB_CONV
+	patch::yc_rgb_conv.init();
+#endif
 	
 	patch::setting_dialog();
 

--- a/patch/macro.h
+++ b/patch/macro.h
@@ -137,6 +137,7 @@
 #define PATCH_SWITCH_DIALOG_NEW_FILE dlg_newfile
 #define PATCH_SWITCH_PLAYBACK_SPEED pb_speed
 #define PATCH_SWITCH_SETTING_NEW_PROJECT setting_newproject
+#define PATCH_SWITCH_YC_RGB_CONV ycrgbconv
 
 #define PATCH_SWITCH_UNDO undo
 #ifdef PATCH_SWITCH_UNDO

--- a/patch/offset_address.hpp
+++ b/patch/offset_address.hpp
@@ -59,6 +59,7 @@ namespace OFS {
 
 		constexpr i32 getpixeldata = 0x09a65c;
 		constexpr i32 rgb2yc = 0x06fed0;
+		constexpr i32 yc_conv_w_loop_count = 0x1e4300;
 
 		constexpr i32 exedit_max_h_add8 = 0x135c64;
 		constexpr i32 exedit_buffer_line = 0x135c68;
@@ -108,6 +109,8 @@ namespace OFS {
 
 		
 		constexpr i32 exedit_edit_open = 0x03ac30;
+
+		constexpr i32 do_multi_thread_func = 0x06c650;
 
 		constexpr i32 exfunc_10 = 0x04abe0;
 		constexpr i32 exfunc_08 = 0x04ab40;

--- a/patch/patch.hpp
+++ b/patch/patch.hpp
@@ -83,3 +83,4 @@
 #include "patch_aup_layer_setting.hpp"
 #include "patch_failed_file_drop.hpp"
 #include "patch_failed_longer_path.hpp"
+#include "patch_yc_rgb_conv.hpp"

--- a/patch/patch.vcxproj
+++ b/patch/patch.vcxproj
@@ -1,23 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|Win32">
-      <Configuration>Debug</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release_PDB|Win32">
-      <Configuration>Release_PDB</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|Win32">
-      <Configuration>Release</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="feature">
+      <UniqueIdentifier>{f2c356a4-9aa7-4917-b27b-4b37a59cc03e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="feature\fast">
+      <UniqueIdentifier>{0921e89c-9ee4-4242-9edf-9f1278a8fd04}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="util">
+      <UniqueIdentifier>{42fd95df-c430-425e-839f-50891f36ebff}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="add_dll_ref.hpp" />
-    <ClInclude Include="config.hpp" />
-    <ClInclude Include="config_rw.hpp" />
     <ClInclude Include="cryptostring.hpp" />
     <ClInclude Include="debug_log.hpp" />
     <ClInclude Include="gate.hpp" />
@@ -34,135 +28,323 @@
     <ClInclude Include="offset_address.hpp" />
     <ClInclude Include="overwrite_resource.hpp" />
     <ClInclude Include="patch.hpp" />
-    <ClInclude Include="patch_access_key.hpp" />
-    <ClInclude Include="patch_add_extension.hpp" />
-    <ClInclude Include="patch_alpha_bg.hpp" />
-    <ClInclude Include="patch_aup_layer_setting.hpp" />
-    <ClInclude Include="patch_aup_scene_setting.hpp" />
-    <ClInclude Include="patch_aviutl_wndproc_override.hpp" />
-    <ClInclude Include="patch_base.hpp" />
-    <ClInclude Include="patch_blend.hpp" />
-    <ClInclude Include="patch_colorpalette_cache.hpp" />
-    <ClInclude Include="patch_console.hpp" />
-    <ClInclude Include="patch_copybuffer_smem.hpp" />
-    <ClInclude Include="patch_dialog_new_file.hpp" />
-    <ClInclude Include="patch_exception_history.hpp" />
-    <ClInclude Include="patch_exception_log.hpp" />
-    <ClInclude Include="patch_exception_log_dialog.hpp" />
-    <ClInclude Include="patch_exeditwindow_sizing.hpp" />
-    <ClInclude Include="patch_exo_aviutlfilter.hpp" />
-    <ClInclude Include="patch_exo_fold_gui.hpp" />
-    <ClInclude Include="patch_exo_midpt_and_tra.hpp" />
-    <ClInclude Include="patch_exo_sceneidx.hpp" />
-    <ClInclude Include="patch_exo_specialcolorconv.hpp" />
-    <ClInclude Include="patch_exo_trackminusval.hpp" />
-    <ClInclude Include="patch_exo_trackparam.hpp" />
-    <ClInclude Include="patch_failed_file_drop.hpp" />
-    <ClInclude Include="patch_failed_longer_path.hpp" />
-    <ClInclude Include="patch_failed_sjis_msgbox.hpp" />
-    <ClInclude Include="patch_fast.hpp" />
-    <ClInclude Include="patch_fast_border.hpp" />
-    <ClInclude Include="patch_fast_cl.hpp" />
-    <ClInclude Include="patch_fast_create_figure.hpp" />
-    <ClInclude Include="patch_fast_directionalblur.hpp" />
-    <ClInclude Include="patch_fast_displacementmap.hpp" />
-    <ClInclude Include="patch_fast_exeditwindow.hpp" />
-    <ClInclude Include="patch_fast_flash.hpp" />
-    <ClInclude Include="patch_fast_getputpixeldata.hpp" />
-    <ClInclude Include="patch_fast_glow.hpp" />
-    <ClInclude Include="patch_fast_lensblur.hpp" />
-    <ClInclude Include="patch_fast_polortransform.hpp" />
-    <ClInclude Include="patch_fast_radiationalblur.hpp" />
-    <ClInclude Include="patch_fast_setting_dialog.hpp" />
-    <ClInclude Include="patch_fast_text.hpp" />
-    <ClInclude Include="patch_fileinfo.hpp" />
-    <ClInclude Include="patch_font_dialog.hpp" />
-    <ClInclude Include="patch_helpful_msgbox.hpp" />
-    <ClInclude Include="patch_ignore_media_param_reset.hpp" />
-    <ClInclude Include="patch_lua.hpp" />
-    <ClInclude Include="patch_lua_getvalueex.hpp" />
-    <ClInclude Include="patch_lua_rand.hpp" />
-    <ClInclude Include="patch_lua_randex.hpp" />
-    <ClInclude Include="patch_obj_colorcorrection.hpp" />
-    <ClInclude Include="patch_obj_glow.hpp" />
-    <ClInclude Include="patch_obj_lensblur.hpp" />
-    <ClInclude Include="patch_obj_noise.hpp" />
-    <ClInclude Include="patch_obj_specialcolorconv.hpp" />
-    <ClInclude Include="patch_playback_speed.hpp" />
-    <ClInclude Include="patch_rclickmenu_delete.hpp" />
-    <ClInclude Include="patch_rclickmenu_split.hpp" />
-    <ClInclude Include="patch_redo.hpp" />
-    <ClInclude Include="patch_scroll_objdlg.hpp" />
-    <ClInclude Include="patch_setting_dialog_excolorconfig.hpp" />
-    <ClInclude Include="patch_setting_dialog_wndproc_override.hpp" />
-    <ClInclude Include="patch_setting_gui.hpp" />
-    <ClInclude Include="patch_setting_new_project.hpp" />
-    <ClInclude Include="patch_splash.hpp" />
-    <ClInclude Include="patch_susie_load.hpp" />
-    <ClInclude Include="patch_sysinfo_write.hpp" />
-    <ClInclude Include="patch_text_op_size.hpp" />
-    <ClInclude Include="patch_theme_cc.hpp" />
-    <ClInclude Include="patch_tra_aviutlfilter.hpp" />
-    <ClInclude Include="patch_tra_change_drawfilter.hpp" />
-    <ClInclude Include="patch_tra_specified_speed.hpp" />
-    <ClInclude Include="patch_undo.hpp" />
-    <ClInclude Include="restorable_patch.hpp" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="stopwatch.hpp" />
-    <ClInclude Include="timer.hpp" />
-    <ClInclude Include="util.hpp" />
-    <ClInclude Include="util_int.hpp" />
-    <ClInclude Include="util_magic.hpp" />
-    <ClInclude Include="util_others.hpp" />
-    <ClInclude Include="util_pe.hpp" />
-    <ClInclude Include="util_resource.hpp" />
     <ClInclude Include="version.hpp" />
-    <ClInclude Include="patch_setting_dialog_move.hpp" />
+    <ClInclude Include="add_dll_ref.hpp" />
+    <ClInclude Include="patch_access_key.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_alpha_bg.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_aviutl_wndproc_override.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_console.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_copybuffer_smem.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_exception_history.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_exception_log.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_exception_log_dialog.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_exeditwindow_sizing.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_exo_aviutlfilter.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_exo_sceneidx.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_exo_specialcolorconv.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_exo_trackminusval.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_exo_trackparam.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_font_dialog.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_helpful_msgbox.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_ignore_media_param_reset.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_lua.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_lua_getvalueex.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_lua_rand.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_lua_randex.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_scroll_objdlg.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_setting_gui.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_splash.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_susie_load.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_sysinfo_write.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_text_op_size.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_theme_cc.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_fast_setting_dialog.hpp">
+      <Filter>feature\fast</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_fast_exeditwindow.hpp">
+      <Filter>feature\fast</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_fast_getputpixeldata.hpp">
+      <Filter>feature\fast</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_fast_polortransform.hpp">
+      <Filter>feature\fast</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_fast_radiationalblur.hpp">
+      <Filter>feature\fast</Filter>
+    </ClInclude>
+    <ClInclude Include="util_resource.hpp">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="util.hpp">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="util_int.hpp">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="util_magic.hpp">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="util_others.hpp">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="util_pe.hpp">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_setting_dialog_wndproc_override.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_setting_dialog_move.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_undo.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="config.hpp" />
+    <ClInclude Include="patch_base.hpp" />
+    <ClInclude Include="restorable_patch.hpp" />
+    <ClInclude Include="config_rw.hpp" />
+    <ClInclude Include="patch_redo.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_fast.hpp">
+      <Filter>feature\fast</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_fast_cl.hpp">
+      <Filter>feature\fast</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_fast_flash.hpp">
+      <Filter>feature\fast</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_tra_aviutlfilter.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_fast_text.hpp">
+      <Filter>feature\fast</Filter>
+    </ClInclude>
+    <ClInclude Include="timer.hpp" />
+    <ClInclude Include="patch_setting_dialog_excolorconfig.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_fast_border.hpp">
+      <Filter>feature\fast</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_fast_directionalblur.hpp">
+      <Filter>feature\fast</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_fast_lensblur.hpp">
+      <Filter>feature\fast</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_obj_lensblur.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_obj_noise.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_blend.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_rclickmenu_delete.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_rclickmenu_split.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_tra_change_drawfilter.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_tra_specified_speed.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_failed_sjis_msgbox.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_fast_displacementmap.hpp">
+      <Filter>feature\fast</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_fast_create_figure.hpp">
+      <Filter>feature\fast</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_obj_colorcorrection.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
+    <ClInclude Include="patch_yc_rgb_conv.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="init.cpp" />
     <ClCompile Include="overwrite_resource.cpp" />
     <ClCompile Include="patch.cpp" />
-    <ClCompile Include="patch_add_extension.cpp" />
-    <ClCompile Include="patch_aviutl_wndproc_override.cpp" />
-    <ClCompile Include="patch_blend.cpp" />
-    <ClCompile Include="patch_exception_log.cpp" />
-    <ClCompile Include="patch_exception_log_dialog.cpp" />
-    <ClCompile Include="patch_exo_trackminusval.cpp" />
-    <ClCompile Include="patch_failed_longer_path.cpp" />
-    <ClCompile Include="patch_failed_sjis_msgbox.cpp" />
-    <ClCompile Include="patch_fast_border.cpp" />
-    <ClCompile Include="patch_fast_create_figure.cpp" />
-    <ClCompile Include="patch_fast_directionalblur.cpp" />
-    <ClCompile Include="patch_fast_displacementmap.cpp" />
-    <ClCompile Include="patch_fast_exeditwindow.cpp" />
-    <ClCompile Include="patch_fast_flash.cpp" />
-    <ClCompile Include="patch_fast_getputpixeldata.cpp" />
-    <ClCompile Include="patch_fast_glow.cpp" />
-    <ClCompile Include="patch_fast_lensblur.cpp" />
-    <ClCompile Include="patch_fast_polortransform.cpp" />
-    <ClCompile Include="patch_fast_radiationalblur.cpp" />
-    <ClCompile Include="patch_fast_setting_dialog.cpp" />
-    <ClCompile Include="patch_fast_text.cpp" />
-    <ClCompile Include="patch_helpful_msgbox.cpp" />
-    <ClCompile Include="patch_lua.cpp" />
-    <ClCompile Include="patch_lua_getvalueex.cpp" />
-    <ClCompile Include="patch_lua_rand.cpp" />
-    <ClCompile Include="patch_lua_randex.cpp" />
-    <ClCompile Include="patch_console.cpp" />
-    <ClCompile Include="patch_obj_colorcorrection.cpp" />
-    <ClCompile Include="patch_obj_lensblur.cpp" />
-    <ClCompile Include="patch_rclickmenu_delete.cpp" />
-    <ClCompile Include="patch_rclickmenu_split.cpp" />
-    <ClCompile Include="patch_redo.cpp" />
-    <ClCompile Include="patch_setting_dialog_excolorconfig.cpp" />
-    <ClCompile Include="patch_setting_dialog_wndproc_override.cpp" />
-    <ClCompile Include="patch_setting_new_project.cpp" />
-    <ClCompile Include="patch_splash.cpp" />
-    <ClCompile Include="patch_susie_load.cpp" />
-    <ClCompile Include="patch_tra_change_drawfilter.cpp" />
-    <ClCompile Include="patch_undo.cpp" />
-    <ClCompile Include="util_others.cpp" />
+    <ClCompile Include="patch_aviutl_wndproc_override.cpp">
+      <Filter>feature</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_exception_log.cpp">
+      <Filter>feature</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_exception_log_dialog.cpp">
+      <Filter>feature</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_exo_trackminusval.cpp">
+      <Filter>feature</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_helpful_msgbox.cpp">
+      <Filter>feature</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_lua.cpp">
+      <Filter>feature</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_lua_getvalueex.cpp">
+      <Filter>feature</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_lua_rand.cpp">
+      <Filter>feature</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_lua_randex.cpp">
+      <Filter>feature</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_console.cpp">
+      <Filter>feature</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_splash.cpp">
+      <Filter>feature</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_susie_load.cpp">
+      <Filter>feature</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_fast_getputpixeldata.cpp">
+      <Filter>feature\fast</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_fast_polortransform.cpp">
+      <Filter>feature\fast</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_fast_radiationalblur.cpp">
+      <Filter>feature\fast</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_fast_setting_dialog.cpp">
+      <Filter>feature\fast</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_fast_exeditwindow.cpp">
+      <Filter>feature\fast</Filter>
+    </ClCompile>
+    <ClCompile Include="util_others.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_undo.cpp">
+      <Filter>feature</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_setting_dialog_wndproc_override.cpp">
+      <Filter>feature</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_redo.cpp">
+      <Filter>feature</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_fast_flash.cpp">
+      <Filter>feature\fast</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_fast_text.cpp">
+      <Filter>feature\fast</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_setting_dialog_excolorconfig.cpp">
+      <Filter>feature</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_fast_border.cpp">
+      <Filter>feature\fast</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_fast_directionalblur.cpp">
+      <Filter>feature\fast</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_fast_lensblur.cpp">
+      <Filter>feature\fast</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_obj_lensblur.cpp">
+      <Filter>feature</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_blend.cpp">
+      <Filter>feature</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_rclickmenu_delete.cpp">
+      <Filter>feature</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_rclickmenu_split.cpp">
+      <Filter>feature</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_tra_change_drawfilter.cpp">
+      <Filter>feature</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_failed_sjis_msgbox.cpp">
+      <Filter>feature</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_fast_displacementmap.cpp">
+      <Filter>feature\fast</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_fast_create_figure.cpp">
+      <Filter>feature\fast</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_obj_colorcorrection.cpp">
+      <Filter>feature</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_yc_rgb_conv.cpp">
+      <Filter>feature</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="patch.rc" />
@@ -172,169 +354,4 @@
     <None Include="clprogram.cl" />
     <None Include="packages.config" />
   </ItemGroup>
-  <PropertyGroup Label="Globals">
-    <VCProjectVersion>16.0</VCProjectVersion>
-    <Keyword>Win32Proj</Keyword>
-    <ProjectGuid>{20c4ed31-b17f-445a-90fe-77f8119f831b}</ProjectGuid>
-    <RootNamespace>patch</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-  </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>MultiByte</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_PDB|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>MultiByte</CharacterSet>
-  </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <ImportGroup Label="ExtensionSettings">
-  </ImportGroup>
-  <ImportGroup Label="Shared">
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_PDB|Win32'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <LinkIncremental>true</LinkIncremental>
-    <TargetExt>.aul</TargetExt>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <LinkIncremental>false</LinkIncremental>
-    <TargetExt>.aul</TargetExt>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_PDB|Win32'">
-    <LinkIncremental>false</LinkIncremental>
-    <TargetExt>.aul</TargetExt>
-  </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
-      <AdditionalIncludeDirectories>aviutl_exedit_sdk;winwrap;%CUDA_PATH%\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalOptions>/source-charset:utf-8 /execution-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
-      <MultiProcessorCompilation>true</MultiProcessorCompilation>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <DelayLoadDLLs>OpenCL.DLL</DelayLoadDLLs>
-      <AdditionalLibraryDirectories>%CUDA_PATH%\lib\Win32</AdditionalLibraryDirectories>
-    </Link>
-    <PostBuildEvent>
-      <Command>xcopy /Y "$(TargetPath)" "$(SolutionDir)test\"
-xcopy /Y "$(TargetPath)" "$(SolutionDir)pack\"
-xcopy /Y "$(SolutionDir)patch.aul.txt" "$(SolutionDir)pack\"
-xcopy /Y "$(SolutionDir)credits.md" "$(SolutionDir)pack\"
-xcopy /Y "$(SolutionDir)LICENSE" "$(SolutionDir)pack\"
-xcopy /Y "$(SolutionDir)COPYING" "$(SolutionDir)pack\"
-xcopy /Y "$(SolutionDir)COPYING.LESSER" "$(SolutionDir)pack\"</Command>
-    </PostBuildEvent>
-    <ResourceCompile>
-      <AdditionalOptions>/c 65001 %(AdditionalOptions)</AdditionalOptions>
-    </ResourceCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
-      <AdditionalIncludeDirectories>aviutl_exedit_sdk;winwrap;%CUDA_PATH%\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalOptions>/source-charset:utf-8 /execution-charset:shift_jis %(AdditionalOptions)</AdditionalOptions>
-      <MultiProcessorCompilation>true</MultiProcessorCompilation>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>false</GenerateDebugInformation>
-      <DelayLoadDLLs>OpenCL.DLL</DelayLoadDLLs>
-      <AdditionalLibraryDirectories>%CUDA_PATH%\lib\Win32</AdditionalLibraryDirectories>
-    </Link>
-    <PostBuildEvent>
-      <Command>copy /Y "$(TargetPath)" "$(SolutionDir)test\$(TargetFileName)"
-copy /Y "$(TargetPath)" "$(SolutionDir)pack\$(TargetFileName)"
-copy /Y "$(SolutionDir)patch.aul.txt" "$(SolutionDir)pack\patch.aul.txt"
-copy /Y "$(SolutionDir)credits.md" "$(SolutionDir)pack\credits.md"
-copy /Y "$(SolutionDir)LICENSE" "$(SolutionDir)pack\LICENSE"
-copy /Y "$(SolutionDir)COPYING" "$(SolutionDir)pack\COPYING"
-copy /Y "$(SolutionDir)COPYING.LESSER" "$(SolutionDir)pack\COPYING.LESSER"</Command>
-    </PostBuildEvent>
-    <ResourceCompile>
-      <AdditionalOptions>/c 65001 %(AdditionalOptions)</AdditionalOptions>
-    </ResourceCompile>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_PDB|Win32'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
-      <AdditionalIncludeDirectories>aviutl_exedit_sdk;winwrap;%CUDA_PATH%\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalOptions>/source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
-      <MultiProcessorCompilation>true</MultiProcessorCompilation>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <DelayLoadDLLs>OpenCL.DLL</DelayLoadDLLs>
-      <AdditionalLibraryDirectories>%CUDA_PATH%\lib\Win32</AdditionalLibraryDirectories>
-    </Link>
-    <PostBuildEvent>
-      <Command>copy /Y "$(TargetPath)" "$(SolutionDir)test\$(TargetFileName)"
-copy /Y "$(TargetPath)" "$(SolutionDir)pack\$(TargetFileName)"
-copy /Y "$(SolutionDir)patch.aul.txt" "$(SolutionDir)pack\patch.aul.txt"
-copy /Y "$(SolutionDir)credits.md" "$(SolutionDir)pack\credits.md"
-copy /Y "$(SolutionDir)LICENSE" "$(SolutionDir)pack\LICENSE"
-copy /Y "$(SolutionDir)COPYING" "$(SolutionDir)pack\COPYING"
-copy /Y "$(SolutionDir)COPYING.LESSER" "$(SolutionDir)pack\COPYING.LESSER"</Command>
-    </PostBuildEvent>
-    <ResourceCompile>
-      <AdditionalOptions>/c 65001 %(AdditionalOptions)</AdditionalOptions>
-    </ResourceCompile>
-  </ItemDefinitionGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\boost.1.79.0\build\boost.targets" Condition="Exists('..\packages\boost.1.79.0\build\boost.targets')" />
-    <Import Project="..\packages\boost_system-vc143.1.79.0\build\boost_system-vc143.targets" Condition="Exists('..\packages\boost_system-vc143.1.79.0\build\boost_system-vc143.targets')" />
-  </ImportGroup>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>このプロジェクトは、このコンピューター上にない NuGet パッケージを参照しています。それらのパッケージをダウンロードするには、[NuGet パッケージの復元] を使用します。詳細については、http://go.microsoft.com/fwlink/?LinkID=322105 を参照してください。見つからないファイルは {0} です。</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\boost.1.79.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost.1.79.0\build\boost.targets'))" />
-    <Error Condition="!Exists('..\packages\boost_system-vc143.1.79.0\build\boost_system-vc143.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\boost_system-vc143.1.79.0\build\boost_system-vc143.targets'))" />
-  </Target>
 </Project>

--- a/patch/patch.vcxproj.filters
+++ b/patch/patch.vcxproj.filters
@@ -226,6 +226,9 @@
     <ClInclude Include="patch_obj_colorcorrection.hpp">
       <Filter>feature</Filter>
     </ClInclude>
+    <ClInclude Include="patch_yc_rgb_conv.hpp">
+      <Filter>feature</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="init.cpp" />
@@ -337,6 +340,9 @@
       <Filter>feature\fast</Filter>
     </ClCompile>
     <ClCompile Include="patch_obj_colorcorrection.cpp">
+      <Filter>feature</Filter>
+    </ClCompile>
+    <ClCompile Include="patch_yc_rgb_conv.cpp">
       <Filter>feature</Filter>
     </ClCompile>
   </ItemGroup>

--- a/patch/patch_yc_rgb_conv.cpp
+++ b/patch/patch_yc_rgb_conv.cpp
@@ -1,0 +1,28 @@
+/*
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "patch_yc_rgb_conv.hpp"
+
+
+#ifdef PATCH_SWITCH_YC_RGB_CONV
+namespace patch {
+
+    void __cdecl yc_rgb_conv_t::do_multi_thread_func_wrap(AviUtl::MultiThreadFunc func,BOOL flag) {
+        if (0 < *(int*)(GLOBAL::exedit_base + OFS::ExEdit::yc_conv_w_loop_count)) {
+            reinterpret_cast<void(__cdecl*)(AviUtl::MultiThreadFunc, BOOL)>(GLOBAL::exedit_base + OFS::ExEdit::do_multi_thread_func)(func, flag);
+        }
+    }
+} // namespace patch
+#endif // ifdef PATCH_SWITCH_YC_RGB_CONV

--- a/patch/patch_yc_rgb_conv.hpp
+++ b/patch/patch_yc_rgb_conv.hpp
@@ -1,0 +1,82 @@
+/*
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+#include "macro.h"
+
+#ifdef PATCH_SWITCH_YC_RGB_CONV
+
+#include <exedit.hpp>
+
+#include "global.hpp"
+#include "offset_address.hpp"
+#include "util.hpp"
+
+#include "config_rw.hpp"
+
+namespace patch {
+
+    // init at exedit load
+    // YC_RGB変換の際に幅0のオブジェクトが渡されたときにエラーとなるのを修正(主に改行のみのテキスト)
+
+    inline class yc_rgb_conv_t {
+
+        static void __cdecl do_multi_thread_func_wrap(AviUtl::MultiThreadFunc func, BOOL flag);
+
+        bool enabled = true;
+        bool enabled_i;
+        inline static const char key[] = "yc_rgb_conv";
+    public:
+        void init() {
+            enabled_i = enabled;
+
+            if (!enabled_i)return;
+
+            {   // rgb2yc normal
+                OverWriteOnProtectHelper h(GLOBAL::exedit_base + 0x6f585, 28);
+                h.replaceNearJmp(0, do_multi_thread_func_wrap);
+                h.replaceNearJmp(24, do_multi_thread_func_wrap);
+            }
+            {   // rgb2yc
+                OverWriteOnProtectHelper h(GLOBAL::exedit_base + 0x6f8a3, 31);
+                h.replaceNearJmp(0, do_multi_thread_func_wrap);
+                h.replaceNearJmp(27, do_multi_thread_func_wrap);
+            }
+
+            {   // yc2rgb
+                ReplaceNearJmp(GLOBAL::exedit_base + 0x6fbb8, do_multi_thread_func_wrap);
+                // もう1つの方は置き換え不要
+            }
+
+        }
+
+        void switching(bool flag) {
+            enabled = flag;
+        }
+
+        bool is_enabled() { return enabled; }
+        bool is_enabled_i() { return enabled_i; }
+
+        void switch_load(ConfigReader& cr) {
+            cr.regist(key, [this](json_value_s* value) {
+                ConfigReader::load_variable(value, enabled);
+                });
+        }
+
+        void switch_store(ConfigWriter& cw) {
+            cw.append(key, enabled);
+        }
+    } yc_rgb_conv;
+} // namespace patch
+
+#endif // ifdef PATCH_SWITCH_YC_RGB_CONV


### PR DESCRIPTION
**変更点**
YC_RGB変換の際に幅0のオブジェクトが渡されたときにエラーとなるのを修正(主に改行のみのテキスト)
https://scrapbox.io/ePi5131/6faa6,6faf4,6fe1a

**内容の精査**
以下の点について教えてください。
- [〇] コードにおかしな点がないことを確認しました。
- [△] 実際にビルドして試しました。← テスト版でのみ確認しました
