### PR TITLE
グループ制御とカメラ制御を併用しているシーンを呼び出すと起こる不具合を修正

### DIFF
--- a/patch.aul.txt
+++ b/patch.aul.txt
@@ -92,6 +92,7 @@ https://scrapbox.io/ePi5131/patch.aul
     ・レイヤー情報を保存するかどうかの判定方法を変える(従来:オブジェクトが存在する→変更:レイヤー情報が初期値でない)
     ・読み込もうとしたファイルパスが長くて失敗するときにメッセージを出す/エラーが発生するのを修正
     ・ドロップ処理で最終的に何も行われなかったときにメッセージを出力する
+    ・グループ制御とカメラ制御を併用しているシーンを呼び出すと起こる不具合を修正
 
     追加
     ・コンソールの表示
@@ -216,6 +217,7 @@ https://scrapbox.io/ePi5131/patch.aul
 		"add_extension" : boolean, ; 動画、音声ファイル参照の時、exedit.iniにある拡張子を追加する (既定値: true)
 		"new_project_editbox" : boolean, ; 新規プロジェクト作成ダイアログの画像サイズ入力欄の幅を広げる (既定値: true)
 		"playback_speed" : boolean, ; 中間点で再生速度を変更した時、そこまでの中間点の数だけ速度変化が遅れて反映されるバグの修正 (既定値: true)
+		"group_camera_scene" : boolean, ; グループ制御とカメラ制御を併用しているシーンを呼び出すと起こる不具合を修正 (既定値: true)
         "undo" : boolean, ; 元に戻す 関連のバグ修正 (既定値: true)
         "undo.redo" : boolean, ; やり直す を追加 (既定値: true)
 		"console" : boolean, ; コンソール (既定値: true)

--- a/patch/config.hpp
+++ b/patch/config.hpp
@@ -182,6 +182,9 @@ public:
             #ifdef PATCH_SWITCH_PLAYBACK_SPEED
                 patch::playback_speed.switch_load(cr);
             #endif
+            #ifdef PATCH_SWITCH_GROUP_CAMERA_SCENE
+                patch::group_camera_scene.switch_load(cr);
+            #endif
 		
 		    #ifdef PATCH_SWITCH_UNDO
                 patch::undo.switch_load(cr);
@@ -510,6 +513,9 @@ public:
             #endif
             #ifdef PATCH_SWITCH_PLAYBACK_SPEED
                 patch::playback_speed.switch_store(switch_);
+            #endif
+            #ifdef PATCH_SWITCH_GROUP_CAMERA_SCENE
+                patch::group_camera_scene.switch_store(switch_);
             #endif
 
 		    #ifdef PATCH_SWITCH_UNDO

--- a/patch/init.cpp
+++ b/patch/init.cpp
@@ -225,6 +225,9 @@ void init_t::InitAtExeditLoad() {
 #ifdef PATCH_SWITCH_PLAYBACK_SPEED
 	patch::playback_speed.init();
 #endif
+#ifdef PATCH_SWITCH_GROUP_CAMERA_SCENE
+	patch::group_camera_scene.init();
+#endif
 	
 	patch::setting_dialog();
 

--- a/patch/macro.h
+++ b/patch/macro.h
@@ -137,6 +137,7 @@
 #define PATCH_SWITCH_DIALOG_NEW_FILE dlg_newfile
 #define PATCH_SWITCH_PLAYBACK_SPEED pb_speed
 #define PATCH_SWITCH_SETTING_NEW_PROJECT setting_newproject
+#define PATCH_SWITCH_GROUP_CAMERA_SCENE group_camera_scene
 
 #define PATCH_SWITCH_UNDO undo
 #ifdef PATCH_SWITCH_UNDO

--- a/patch/patch.hpp
+++ b/patch/patch.hpp
@@ -83,3 +83,4 @@
 #include "patch_aup_layer_setting.hpp"
 #include "patch_failed_file_drop.hpp"
 #include "patch_failed_longer_path.hpp"
+#include "patch_group_camera_scene.hpp"

--- a/patch/patch_group_camera_scene.hpp
+++ b/patch/patch_group_camera_scene.hpp
@@ -1,0 +1,85 @@
+/*
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+#include "macro.h"
+
+#ifdef PATCH_SWITCH_GROUP_CAMERA_SCENE
+#include <memory>
+
+#include <exedit.hpp>
+
+#include "global.hpp"
+#include "offset_address.hpp"
+#include "util.hpp"
+
+
+namespace patch {
+
+    // init at exedit load
+    // グループ制御とカメラ制御を併用しているシーンを呼び出すと起こる不具合を修正
+    inline class group_camera_scene_t {
+        bool enabled = true;
+        bool enabled_i;
+        inline static const char key[] = "group_camera_scene";
+    public:
+        void init() {
+            enabled_i = enabled;
+
+            if (!enabled_i)return;
+
+            auto& cursor = GLOBAL::executable_memory_cursor;
+
+            OverWriteOnProtectHelper h(GLOBAL::exedit_base + 0x01b056, 6);
+            h.store_i16(0, '\x90\xe8');
+            h.replaceNearJmp(2, cursor);
+            /*
+                1001b056 8b5004             mov     edx,dword ptr [eax+04] ; edx = obj->layer_disp
+                1001b059 8b4d10             mov     ecx,dword ptr [ebp+10]
+
+                ↓
+
+                00000000 8b90c0050000       mov     edx,dword ptr [eax+000005c0] ; ebp = obj->layer_setting
+                00000000 8b4d10             mov     ecx,dword ptr [ebp+10]
+            */
+
+            static const char code_put[] =
+                "\x8b\x90\xc0\x05\x00\x00" // mov     edx,dword ptr [eax+000005c0]
+                "\x8b\x4d\x10"             // mov     ecx,dword ptr [ebp+10]
+                "\xc3"                     // ret
+                ;
+
+            memcpy(cursor, code_put, sizeof(code_put) - 1);
+            cursor += sizeof(code_put) - 1;
+        }
+
+        void switching(bool flag) {
+            enabled = flag;
+        }
+
+        bool is_enabled() { return enabled; }
+        bool is_enabled_i() { return enabled_i; }
+
+        void switch_load(ConfigReader& cr) {
+            cr.regist(key, [this](json_value_s* value) {
+                ConfigReader::load_variable(value, enabled);
+                });
+        }
+
+        void switch_store(ConfigWriter& cw) {
+            cw.append(key, enabled);
+        }
+    } group_camera_scene;
+} // namespace patch
+
+#endif // ifdef PATCH_SWITCH_GROUP_CAMERA_SCENE


### PR DESCRIPTION
**変更点**
https://scrapbox.io/ePi5131/%E3%82%AB%E3%83%A1%E3%83%A9%E5%88%B6%E5%BE%A1%E3%81%A8%E3%82%B0%E3%83%AB%E3%83%BC%E3%83%97%E5%88%B6%E5%BE%A1%E3%81%A8%E3%82%B7%E3%83%BC%E3%83%B3%E3%81%AE%E4%BD%B5%E7%94%A8
を修正

**内容の精査**
以下の点について教えてください。
- [〇] コードにおかしな点がないことを確認しました。
- [△] 実際にビルドして試しました。←テスト版環境のみにて行っていますが、このブランチでは行っていません
