### PR TITLE
メニューの[編集]の文字列が変わるとaviutl.keyの設定を反映できない

### DIFF
--- a/patch/config.hpp
+++ b/patch/config.hpp
@@ -56,6 +56,10 @@ public:
         cr.regist("switch", [](json_value_s* value) {
             ConfigReader cr(value);
             
+            
+		    #ifdef PATCH_SWITCH_KEYCONFIG
+                patch::KeyConfig.switch_load(cr);
+		    #endif
 		    #ifdef PATCH_SWITCH_ACCESS_KEY
                 patch::access_key.switch_load(cr);
 		    #endif
@@ -385,6 +389,9 @@ public:
         {
             ConfigWriter switch_(++level);
             
+		    #ifdef PATCH_SWITCH_KEYCONFIG
+                patch::KeyConfig.switch_store(switch_);
+		    #endif
 		    #ifdef PATCH_SWITCH_ACCESS_KEY
                 patch::access_key.switch_store(switch_);
 		    #endif

--- a/patch/init.cpp
+++ b/patch/init.cpp
@@ -84,6 +84,10 @@ void init_t::InitAtPatchLoaded() {
 	patch::sysinfo_info_write();
 #endif
 
+#ifdef PATCH_SWITCH_KEYCONFIG
+	patch::KeyConfig.init();
+#endif
+
 #ifdef PATCH_SWITCH_ACCESS_KEY
 	patch::access_key.init();
 #endif

--- a/patch/macro.h
+++ b/patch/macro.h
@@ -100,6 +100,7 @@
 #define PATCH_SWITCH_EXCEPTION_LOG
 #define PATCH_SWITCH_SYSINFO_MODIFY
 
+#define PATCH_SWITCH_KEYCONFIG key_config
 #define PATCH_SWITCH_ACCESS_KEY access_key
 #define PATCH_SWITCH_COLORPALETTE_CACHE colorpalette_cache
 #define PATCH_SWITCH_TRA_AVIUTL_FILTER tra_aviutl_filter

--- a/patch/patch.hpp
+++ b/patch/patch.hpp
@@ -83,3 +83,4 @@
 #include "patch_aup_layer_setting.hpp"
 #include "patch_failed_file_drop.hpp"
 #include "patch_failed_longer_path.hpp"
+#include "patch_keyconfig.hpp"

--- a/patch/patch_keyconfig.cpp
+++ b/patch/patch_keyconfig.cpp
@@ -1,0 +1,64 @@
+/*
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "patch_keyconfig.hpp"
+#ifdef PATCH_SWITCH_KEYCONFIG
+
+namespace patch {
+    /*
+    一つ目のカッコ内は言語リソース変更で変わってしまうので、それ以降のみの一致を許容する必要がある
+    ・[編集][プラグイン1][メニュー1]
+    ・[Edit][プラグイン1][メニュー1]
+    ・[編集(&E)][プラグイン1][メニュー1]
+    */
+    int __stdcall KeyConfig_t::lstrcmpA_wrap(char* menu_data_str, char* keyfile_data_str) {
+        if (lstrcmpA(menu_data_str, keyfile_data_str) == 0) {
+            return 0;
+        }
+
+        // 文字列の後ろから比較していき、"]["が2回出現するまで一致していたら同じと判断
+        // プラグイン名やメニューアイテム名に"]["が含まれていれば判定は狂うけど問題になるケースはほぼ無いはず
+
+        int m = lstrlenA(menu_data_str) - 1; // 最後の']'の分
+        int k = lstrlenA(keyfile_data_str) - 1;
+        int count = 0;
+        int flag = 0;
+        while (0 < m && 0 < k) {
+            m--; k--;
+            if (menu_data_str[m] != keyfile_data_str[k]) {
+                return 1;
+            }
+            switch (menu_data_str[m]) {
+            case '[':
+                flag = 1;
+                break;
+            case ']':
+                if (flag) {
+                    if (count) {
+                        return 0;
+                    }
+                    count++;
+                }
+                // flag = 0;
+                // break;
+            default:
+                flag = 0;
+            }
+        }
+        return 1;
+    }
+
+} // namespace patch
+#endif // ifdef PATCH_SWITCH_KEYCONFIG

--- a/patch/patch_keyconfig.hpp
+++ b/patch/patch_keyconfig.hpp
@@ -1,0 +1,77 @@
+/*
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+#include "macro.h"
+#ifdef PATCH_SWITCH_KEYCONFIG
+#include <exedit.hpp>
+#include "util_magic.hpp"
+#include "global.hpp"
+#include "config_rw.hpp"
+
+namespace patch {
+	// init at patch load
+	// 言語リソースプラグインなどでメニューの「編集」の部分が変わるとaviutl.keyのプラグイン設定部分が正しく読み込めなくなるのを修正
+	inline class KeyConfig_t {
+
+		static int __stdcall lstrcmpA_wrap(char* menu_data_str, char* keyfile_data_str);
+
+
+		bool enabled = true;
+		bool enabled_i;
+		inline static const char key[] = "keyconfig";
+
+
+	public:
+
+		void init() {
+			enabled_i = enabled;
+			if (!enabled_i)return;
+
+			{   // 音声ファイルの再生速度トラックの最大値2000.0のはずが800.0となってしまう処理があるのを修正
+				/*
+                    004331c2 ff1550f24600       call    lstrcmpA
+
+					↓
+
+					004331c2 90                 nop
+					004331c3 e8XxXxXxXx         call    new_function
+				*/
+
+				OverWriteOnProtectHelper h(GLOBAL::aviutl_base + 0x331c2, 6);
+				h.store_i16(0, '\x90\xe8');
+				h.replaceNearJmp(2, &lstrcmpA_wrap);
+			}
+
+		}
+
+		void switching(bool flag) { enabled = flag; }
+
+		bool is_enabled() { return enabled; }
+		bool is_enabled_i() { return enabled_i; }
+
+		void switch_load(ConfigReader& cr) {
+			cr.regist(key, [this](json_value_s* value) {
+				ConfigReader::load_variable(value, enabled);
+				});
+		}
+
+		void switch_store(ConfigWriter& cw) {
+			cw.append(key, enabled);
+		}
+
+	} KeyConfig;
+} // namespace patch
+#endif // ifdef PATCH_SWITCH_KEYCONFIG


### PR DESCRIPTION
**関係する Issue**
- #9  を閉じる
- #9  に関連

**変更点**
- [編集]の部分を無視した判定を追加した。
- アクセスキー追加してもショートカットがズレなくなります。

**内容の精査**
以下の点について教えてください。
- [〇] コードにおかしな点がないことを確認しました。
- [△] 実際にビルドして試しました。→テスト版環境にてビルドして試しました
