### PR TITLE
シーン切り替え時のバグを修正

### DIFF
--- a/patch.aul.txt
+++ b/patch.aul.txt
@@ -92,6 +92,8 @@ https://scrapbox.io/ePi5131/patch.aul
     ・レイヤー情報を保存するかどうかの判定方法を変える(従来:オブジェクトが存在する→変更:レイヤー情報が初期値でない)
     ・読み込もうとしたファイルパスが長くて失敗するときにメッセージを出す/エラーが発生するのを修正
     ・ドロップ処理で最終的に何も行われなかったときにメッセージを出力する
+    ・Shiftを押しながらシーン切り替えをすると範囲選択がされることがあるのを修正
+    ・シーン切り替え時に拡張編集のウィンドウタイトル部分が変わらないのを修正
 
     追加
     ・コンソールの表示
@@ -216,6 +218,7 @@ https://scrapbox.io/ePi5131/patch.aul
 		"add_extension" : boolean, ; 動画、音声ファイル参照の時、exedit.iniにある拡張子を追加する (既定値: true)
 		"new_project_editbox" : boolean, ; 新規プロジェクト作成ダイアログの画像サイズ入力欄の幅を広げる (既定値: true)
 		"playback_speed" : boolean, ; 中間点で再生速度を変更した時、そこまでの中間点の数だけ速度変化が遅れて反映されるバグの修正 (既定値: true)
+		"change_disp_scene" : boolean, ; シーン切り替え時のバグを修正 (既定値: true)
         "undo" : boolean, ; 元に戻す 関連のバグ修正 (既定値: true)
         "undo.redo" : boolean, ; やり直す を追加 (既定値: true)
 		"console" : boolean, ; コンソール (既定値: true)

--- a/patch/config.hpp
+++ b/patch/config.hpp
@@ -182,6 +182,9 @@ public:
             #ifdef PATCH_SWITCH_PLAYBACK_SPEED
                 patch::playback_speed.switch_load(cr);
             #endif
+            #ifdef PATCH_SWITCH_CHANGE_DISP_SCENE
+                patch::change_disp_scene.switch_load(cr);
+            #endif
 		
 		    #ifdef PATCH_SWITCH_UNDO
                 patch::undo.switch_load(cr);
@@ -510,6 +513,9 @@ public:
             #endif
             #ifdef PATCH_SWITCH_PLAYBACK_SPEED
                 patch::playback_speed.switch_store(switch_);
+            #endif
+            #ifdef PATCH_SWITCH_CHANGE_DISP_SCENE
+                patch::change_disp_scene.switch_store(switch_);
             #endif
 
 		    #ifdef PATCH_SWITCH_UNDO

--- a/patch/init.cpp
+++ b/patch/init.cpp
@@ -225,6 +225,9 @@ void init_t::InitAtExeditLoad() {
 #ifdef PATCH_SWITCH_PLAYBACK_SPEED
 	patch::playback_speed.init();
 #endif
+#ifdef PATCH_SWITCH_CHANGE_DISP_SCENE
+	patch::change_disp_scene.init();
+#endif
 	
 	patch::setting_dialog();
 

--- a/patch/macro.h
+++ b/patch/macro.h
@@ -137,6 +137,7 @@
 #define PATCH_SWITCH_DIALOG_NEW_FILE dlg_newfile
 #define PATCH_SWITCH_PLAYBACK_SPEED pb_speed
 #define PATCH_SWITCH_SETTING_NEW_PROJECT setting_newproject
+#define PATCH_SWITCH_CHANGE_DISP_SCENE change_dispscene
 
 #define PATCH_SWITCH_UNDO undo
 #ifdef PATCH_SWITCH_UNDO

--- a/patch/offset_address.hpp
+++ b/patch/offset_address.hpp
@@ -26,6 +26,8 @@ namespace OFS {
 		constexpr i32 edit_handle_ptr = 0x08717c;
 		constexpr i32 saveProjectFile = 0x024160;
 		
+		constexpr i32 ini_shiftselect = 0x086398;
+		
 		constexpr i32 str_dot_avi = 0x0745fc; // ".avi"
 		
 		constexpr i32 filter_clipping_and_resize_ptr = 0x07ad58;
@@ -37,6 +39,9 @@ namespace OFS {
 		constexpr i32 aviutl_hwnd = 0x135c6c;
 		constexpr i32 exedit_hwnd = 0x177a44;
 		constexpr i32 settingdialog_hwnd = 0x1539c8;
+		
+		constexpr i32 tl_title = 0x0a4cfc;
+		
 		
 		constexpr i32 blend_yca_normal_func = 0x007df0;
 		constexpr i32 blend_yc_normal_func = 0x007f20;
@@ -106,9 +111,14 @@ namespace OFS {
 		constexpr i32 str_DOUGAFILE = 0x09df6c; // "動画ファイル"
 		constexpr i32 str_ONSEIFILE = 0x0ba698; // "音声ファイル"
 
+		constexpr i32 frame_cursor = 0x1a5304;
+		constexpr i32 frame_n = 0x14d3a0;
+		constexpr i32 double_framerate = 0x0a4068;
+		constexpr i32 double_framerate_scale = 0x0a4060;
 		
 		constexpr i32 exedit_edit_open = 0x03ac30;
 
+		constexpr i32 exfunc = 0x0a41e0;
 		constexpr i32 exfunc_10 = 0x04abe0;
 		constexpr i32 exfunc_08 = 0x04ab40;
 		constexpr i32 func_0x047ad0 = 0x047ad0;

--- a/patch/patch.hpp
+++ b/patch/patch.hpp
@@ -83,3 +83,4 @@
 #include "patch_aup_layer_setting.hpp"
 #include "patch_failed_file_drop.hpp"
 #include "patch_failed_longer_path.hpp"
+#include "patch_change_disp_scene.hpp"

--- a/patch/patch_change_disp_scene.cpp
+++ b/patch/patch_change_disp_scene.cpp
@@ -1,0 +1,52 @@
+/*
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "patch_change_disp_scene.hpp"
+
+#ifdef PATCH_SWITCH_CHANGE_DISP_SCENE
+namespace patch {
+
+	void update_title() {
+		char title[64];
+		int frame = *(int*)(GLOBAL::exedit_base + OFS::ExEdit::frame_cursor);
+		int frame_n = *(int*)(GLOBAL::exedit_base + OFS::ExEdit::frame_n);
+		frame = std::clamp(frame, 0, frame_n - 1);
+
+		double framerate = *(double*)(GLOBAL::exedit_base + OFS::ExEdit::double_framerate);
+		double framerate_scale = *(double*)(GLOBAL::exedit_base + OFS::ExEdit::double_framerate_scale);
+		int centisecond = (int)(100.0 / framerate * (double)frame * framerate_scale);
+		char* tl_title = (char*)(GLOBAL::exedit_base + OFS::ExEdit::tl_title);
+		wsprintfA(title, tl_title, centisecond / 360000, (centisecond % 360000) / 6000, (centisecond % 6000) / 100, centisecond % 100, frame + 1, frame_n);
+
+		SetWindowTextA(*(HWND*)(GLOBAL::exedit_base + OFS::ExEdit::exedit_hwnd), title);
+	}
+
+	int __cdecl change_disp_scene_t::set_frame_wrap(AviUtl::EditHandle* editp, int frame) {
+
+		int* ini_shiftselect = (int*)(GLOBAL::aviutl_base + OFS::AviUtl::ini_shiftselect);
+		int tmp_shiftselect = *ini_shiftselect;
+		*ini_shiftselect = 0;
+
+		auto a_exfunc = (AviUtl::ExFunc*)(GLOBAL::aviutl_base + OFS::AviUtl::exfunc);
+		int ret = a_exfunc->set_frame(editp, frame);
+
+		update_title();
+
+		*ini_shiftselect = tmp_shiftselect;
+
+		return ret;
+	}
+} // namespace patch
+#endif // ifdef PATCH_SWITCH_CHANGE_DISP_SCENE

--- a/patch/patch_change_disp_scene.hpp
+++ b/patch/patch_change_disp_scene.hpp
@@ -1,0 +1,94 @@
+/*
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+#include "macro.h"
+
+#ifdef PATCH_SWITCH_CHANGE_DISP_SCENE
+
+#include <exedit.hpp>
+
+#include "global.hpp"
+#include "offset_address.hpp"
+#include "restorable_patch.hpp"
+
+#include "config_rw.hpp"
+
+namespace patch {
+	// init at exedit load
+	/* シーン切り替え時のバグを修正
+	　　・Shiftを押しながらシーン切り替えをすると範囲選択がされる（システムの設定＞フレーム移動時にSHIFTキーを押している時は範囲選択移動にする の影響）
+	  　・拡張編集のウィンドウキャプションが変わらない
+	*/
+	inline class change_disp_scene_t {
+		static int __cdecl set_frame_wrap(AviUtl::EditHandle* editp, int frame);
+
+		bool enabled = true;
+		bool enabled_i;
+
+		inline static const char key[] = "change_disp_scene";
+
+		inline static int last_id = -1;
+
+	public:
+
+		void init() {
+			enabled_i = enabled;
+
+			if (!enabled_i)return;
+			{
+				/*
+					1002be69 8b4e60             mov     ecx,dword ptr [esi+60]
+					1002be6c 52                 push    edx
+					1002be6d 57                 push    edi
+					1002be6e ff5124             call    dword ptr [ecx+24]
+					1002be71
+					↓
+					1002be69 52                 push    edx
+					1002be6a 57                 push    edi
+					1002be6b 90                 nop
+					1002be6c e8XxXxXxXx         call    new_func
+					1002be71
+
+				*/
+				
+				OverWriteOnProtectHelper h(GLOBAL::exedit_base + 0x02be69, 8);
+				h.store_i32(0, '\x52\x57\x90\xe8');
+				h.replaceNearJmp(4, &set_frame_wrap);
+				
+			}
+
+
+		}
+		void switching(bool flag) {
+			enabled = flag;
+		}
+
+		bool is_enabled() { return enabled; }
+		bool is_enabled_i() { return enabled_i; }
+
+		void switch_load(ConfigReader& cr) {
+			cr.regist(key, [this](json_value_s* value) {
+				ConfigReader::load_variable(value, enabled);
+				});
+		}
+
+		void switch_store(ConfigWriter& cw) {
+			cw.append(key, enabled);
+		}
+
+	} change_disp_scene;
+} // namespace patch
+#endif // ifdef PATCH_SWITCH_CHANGE_DISP_SCENE


### PR DESCRIPTION
**変更点**
・Shiftを押しながらシーン切り替えをすると範囲選択がされるのを修正（システムの設定＞フレーム移動時にSHIFTキーを押している時は範囲選択移動にする の影響）
・シーン切り替え時に拡張編集のウィンドウキャプションが変わらないのを修正

**内容の精査**
以下の点について教えてください。
- [〇] コードにおかしな点がないことを確認しました。
- [△] 実際にビルドして試しました。→テスト版環境にてビルドしました
